### PR TITLE
chore: enable automatic semantic releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,106 @@
+name: Auto Release (Semantic Version)
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-release-main
+  cancel-in-progress: false
+
+jobs:
+  tag-and-release:
+    name: Tag next version
+    runs-on: ubuntu-latest
+    if: github.repository == 'wildking996/bastion'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine next version
+        id: semver
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          latest_tag="$(git describe --tags --match 'v[0-9]*' --abbrev=0 2>/dev/null || true)"
+          if [ -z "$latest_tag" ]; then
+            latest_tag="v0.0.0"
+          fi
+
+          subjects="$(git log --no-merges --format=%s "${latest_tag}..HEAD" || true)"
+          bodies="$(git log --no-merges --format=%b "${latest_tag}..HEAD" || true)"
+
+          bump="none"
+          if echo "$subjects" | grep -Eq '^[a-zA-Z]+(\([^)]+\))?!: '; then
+            bump="major"
+          elif echo "$bodies" | grep -Eq '(^|[[:space:]])BREAKING CHANGE([[:space:]]|:|$)'; then
+            bump="major"
+          elif echo "$subjects" | grep -Eq '^feat(\([^)]+\))?: '; then
+            bump="minor"
+          elif echo "$subjects" | grep -Eq '^(fix|perf)(\([^)]+\))?: '; then
+            bump="patch"
+          fi
+
+          if [ "$bump" = "none" ]; then
+            echo "No Conventional Commit requiring release since ${latest_tag}; skipping."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          v="${latest_tag#v}"
+          major="${v%%.*}"
+          rest="${v#*.}"
+          minor="${rest%%.*}"
+          patch="${rest#*.}"
+
+          case "$bump" in
+            major)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            minor)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            patch)
+              patch=$((patch + 1))
+              ;;
+            *)
+              echo "Unknown bump: $bump"
+              exit 1
+              ;;
+          esac
+
+          new_tag="v${major}.${minor}.${patch}"
+          if git rev-parse -q --verify "refs/tags/${new_tag}" >/dev/null; then
+            echo "Tag ${new_tag} already exists; skipping."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "latest_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+          echo "bump=${bump}" >> "$GITHUB_OUTPUT"
+          echo "new_tag=${new_tag}" >> "$GITHUB_OUTPUT"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        if: steps.semver.outputs.should_release == 'true'
+        shell: bash
+        env:
+          NEW_TAG: ${{ steps.semver.outputs.new_tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+          git push origin "$NEW_TAG"
+


### PR DESCRIPTION
## Goal
Automatically create a new `vX.Y.Z` tag after each merge to `main` when the commits since the last tag contain Conventional Commits.

## How it works
- On every push to `main`, scan commits since the latest `v*` tag.
- Determine SemVer bump:
  - **major**: `type(scope)!:` or `BREAKING CHANGE`
  - **minor**: `feat:`
  - **patch**: `fix:` or `perf:`
- If a bump is needed, create and push the next tag (this triggers the existing `release.yml`).

## Merge guidance
- Prefer **Squash and merge**.
- Make the squash commit message a Conventional Commit, e.g. `feat: Prometheus metrics endpoint`.

## Notes
- If there are no matching Conventional Commits since the last tag, the workflow does nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release tagging workflow based on commit conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->