### PR TITLE
feat: Prometheus metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Key flags (see `./bastion --help` for full list):
 - Error logs: `GET /api/error-logs`, `DELETE /api/error-logs`
 - Shutdown (confirmation code): `POST /api/shutdown/generate-code`, `POST /api/shutdown/verify`
 - Health/metrics: `GET /api/health`, `GET /api/metrics`
+- Prometheus: `GET /metrics`
 
 ## Project Structure
 
@@ -227,6 +228,7 @@ CLI 模式：`./bastion --cli --server http://your-server:7788`
 - 错误日志：`GET /api/error-logs`，`DELETE /api/error-logs`
 - 关闭：`POST /api/shutdown/generate-code`，`POST /api/shutdown/verify`
 - 健康/指标：`GET /api/health`，`GET /api/metrics`
+- Prometheus：`GET /metrics`
 
 ### 结构
 

--- a/TODO.md
+++ b/TODO.md
@@ -58,9 +58,11 @@ Bastion 是一个用 Go 编写的轻量级 SSH 跳板机/代理工具，核心�
 - **复杂度**: 低
 
 #### 4. Prometheus 指标 (Metrics Export)
-- **描述**: 当前已有 `/api/metrics`(JSON)；补充 Prometheus 格式导出
+- **状态**: ✅ 已实现（基础版）
+- **描述**: 已提供 `/metrics`（Prometheus exposition）；`/api/metrics` 仍为 JSON
 - **实现方式**:
-  - 增加 `/metrics`（Prometheus exposition）或在现有 `/api/metrics` 增加 `?format=prom`
+  - 提供 `/metrics`（Prometheus exposition）
+  - 需要补充时可扩展为标准 `go_*/process_*` 全量指标
   - 关键指标: 连接数、流量、错误率、会话状态
   - Go runtime 指标
 - **影响**: 可观测性 ⭐⭐⭐⭐⭐
@@ -216,7 +218,7 @@ Bastion 是一个用 Go 编写的轻量级 SSH 跳板机/代理工具，核心�
 3. ⏳ 暗色主题
 
 ### 中期 (1 个月)
-4. ⏳ Metrics：补 Prometheus 格式导出
+4. ✅ Metrics：Prometheus `/metrics`
 5. ⏳ WebSocket 支持
 6. ⏳ 日志搜索过滤
 

--- a/main.go
+++ b/main.go
@@ -107,6 +107,9 @@ func main() {
 		c.Redirect(http.StatusMovedPermanently, "/web/index.html")
 	})
 
+	// Prometheus metrics (exposition format)
+	r.GET("/metrics", handlers.GetPrometheusMetrics)
+
 	// API routes
 	api := r.Group("/api")
 	{


### PR DESCRIPTION
Closes #1

## Summary
Expose a Prometheus-compatible metrics endpoint for monitoring.

## Acceptance Criteria
- `GET /metrics` returns Prometheus exposition format.
- Existing JSON metrics remain backward compatible.
- CI checks pass on PR.

## Merge guidance
- Prefer **Squash and merge** so the resulting commit message stays Conventional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `/metrics` endpoint exposing Prometheus-format metrics for enhanced monitoring and observability integration.

* **Documentation**
  * Updated README with details about the new Prometheus metrics endpoint and related project structure information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->