### PR TITLE
chore: fix release automation and CI cache

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,6 +1,7 @@
 name: Auto Release (Semantic Version)
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -29,22 +30,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          latest_tag="$(git describe --tags --match 'v[0-9]*' --abbrev=0 2>/dev/null || true)"
+          latest_tag="$(git describe --tags --match 'v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 2>/dev/null || true)"
           if [ -z "$latest_tag" ]; then
             latest_tag="v0.0.0"
           fi
 
-          subjects="$(git log --no-merges --format=%s "${latest_tag}..HEAD" || true)"
-          bodies="$(git log --no-merges --format=%b "${latest_tag}..HEAD" || true)"
+          messages="$(git log --format=%B "${latest_tag}..HEAD" || true)"
 
           bump="none"
-          if echo "$subjects" | grep -Eq '^[a-zA-Z]+(\([^)]+\))?!: '; then
+          if printf '%s\n' "$messages" | grep -Eq '^[a-zA-Z]+(\([^)]+\))?!: '; then
             bump="major"
-          elif echo "$bodies" | grep -Eq '(^|[[:space:]])BREAKING CHANGE([[:space:]]|:|$)'; then
+          elif printf '%s\n' "$messages" | grep -Eq '(^|[[:space:]])BREAKING CHANGE([[:space:]]|:|$)'; then
             bump="major"
-          elif echo "$subjects" | grep -Eq '^feat(\([^)]+\))?: '; then
+          elif printf '%s\n' "$messages" | grep -Eq '^feat(\([^)]+\))?: '; then
             bump="minor"
-          elif echo "$subjects" | grep -Eq '^(fix|perf)(\([^)]+\))?: '; then
+          elif printf '%s\n' "$messages" | grep -Eq '^(fix|perf)(\([^)]+\))?: '; then
             bump="patch"
           fi
 
@@ -103,4 +103,3 @@ jobs:
 
           git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
           git push origin "$NEW_TAG"
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Download dependencies
         run: go mod download


### PR DESCRIPTION
## Fixes
1) Auto-release now detects Conventional Commits even when PRs are merged with merge commits (it scans full commit messages including merge bodies).
2) CI no longer uses a custom Go modules cache step that produced noisy `tar: Cannot open: File exists` errors; it relies on `actions/setup-go` built-in caching.

## Notes
- Auto-release supports manual triggering via `workflow_dispatch`.
- Recommended merge strategy for feature PRs is still **Squash and merge** to keep commit subjects conventional, but merge commits will now work too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow configurations for automated releases and dependency caching, enhancing internal build processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->