### PR TITLE
feat: WebSocket support for HTTP forward proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Bastion is a secure SSH bastion host with local/dynamic forwarding, HTTP auditin
 - SSH connection pooling and session management
 - Dynamic port forwarding (SOCKS5) and local port forwarding
 - HTTP traffic auditing with in-memory logs
+- HTTP forward proxy supports WebSocket Upgrade (frames are tunneled; audit covers the initial HTTP handshake only)
 - Web-based management interface served from `/web`
 - CLI client mode to control a running server (`--cli --server <url>`)
 - Multi-platform builds (Windows, Linux, macOS; GUI and console variants on Windows)
@@ -166,6 +167,7 @@ Bastion 是一个安全的 SSH 跳板机，支持本地/动态转发、HTTP 审�
 - SSH 连接池与会话管理
 - 动态端口转发（SOCKS5）与本地端口转发
 - HTTP 流量审计与内存日志
+- HTTP 正向代理支持 WebSocket Upgrade（升级后按原始 TCP 转发；审计仅覆盖升级前的 HTTP 握手）
 - `/web` 提供的 Web 管理界面
 - CLI 模式远程控制运行中的服务（`--cli --server <url>`）
 - 跨平台构建（Windows/Linux/macOS，Windows 同时提供 GUI 与控制台版本）

--- a/TODO.md
+++ b/TODO.md
@@ -69,11 +69,11 @@ Bastion 是一个用 Go 编写的轻量级 SSH 跳板机/代理工具，核心�
 - **复杂度**: 低
 
 #### 5. WebSocket 支持 (WS Proxy)
+- **状态**: ✅ 已实现（基础版：代理 Upgrade；不解析 WS 帧）
 - **描述**: 代理支持 WebSocket 协议升级
 - **实现方式**:
-  - HTTP 代理支持 UPGRADE 请求
-  - 保持 TCP 隧道但识别 WS 帧
-  - 实时连接状态推送 (Web UI)
+  - HTTP 代理支持 Upgrade: websocket
+  - 升级后切换为原始 TCP 双向转发（不解析 WS 帧，避免影响现有 HTTP 审计解析）
 - **影响**: 现代应用兼容性 ⭐⭐⭐⭐⭐
 - **复杂度**: 中
 

--- a/core/http_proxy_ws_test.go
+++ b/core/http_proxy_ws_test.go
@@ -1,0 +1,94 @@
+package core
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"bastion/config"
+	"bastion/models"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestHTTPProxy_WebSocketUpgrade_ProxiesBidirectional(t *testing.T) {
+	prevAudit := config.Settings.AuditEnabled
+	prevLogLevel := config.Settings.LogLevel
+	prevHandshakeTimeout := config.Settings.Socks5HandshakeTimeoutSeconds
+	t.Cleanup(func() {
+		config.Settings.AuditEnabled = prevAudit
+		config.Settings.LogLevel = prevLogLevel
+		config.Settings.Socks5HandshakeTimeoutSeconds = prevHandshakeTimeout
+	})
+
+	// Avoid needing AuditorInstance in tests.
+	config.Settings.AuditEnabled = false
+	config.Settings.LogLevel = "ERROR"
+	config.Settings.Socks5HandshakeTimeoutSeconds = 2
+
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		for {
+			mt, msg, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if err := conn.WriteMessage(mt, msg); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(backend.Close)
+
+	mapping := &models.Mapping{
+		ID:        "test-http-proxy-ws",
+		LocalHost: "127.0.0.1",
+		LocalPort: 0,
+		Type:      "http",
+	}
+	session := NewHTTPProxySession(mapping, nil)
+	if err := session.Start(); err != nil {
+		t.Fatalf("Start HTTP proxy session: %v", err)
+	}
+	t.Cleanup(session.Stop)
+
+	proxyURL, err := url.Parse("http://" + session.listener.Addr().String())
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+
+	wsURL := "ws" + strings.TrimPrefix(backend.URL, "http") + "/echo"
+	dialer := websocket.Dialer{
+		Proxy: http.ProxyURL(proxyURL),
+	}
+
+	c, _, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial ws via proxy: %v", err)
+	}
+	defer c.Close()
+
+	if err := c.WriteMessage(websocket.TextMessage, []byte("ping")); err != nil {
+		t.Fatalf("write ws message: %v", err)
+	}
+
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, got, err := c.ReadMessage()
+	if err != nil {
+		t.Fatalf("read ws message: %v", err)
+	}
+	if string(got) != "ping" {
+		t.Fatalf("unexpected echo: %q", string(got))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/go-playground/validator/v10 v10.15.5 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 h1:Xim43kblpZXfIBQsbu
 github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26/go.mod h1:dDKJzRmX4S37WGHujM7tX//fmj1uioxKzKxz3lo4HJo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=


### PR DESCRIPTION
Closes #2

Adds WebSocket Upgrade (101 Switching Protocols) support to the HTTP forward proxy and includes tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP forward proxy now supports WebSocket Upgrade with bidirectional frame tunneling.

* **Documentation**
  * Updated documentation to reflect WebSocket Upgrade support in both English and Chinese.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->