### PR TITLE
feat(ssh): keepalive and idle lifecycle for pooled connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Environment variables (overridden by flags where available):
 - `SSH_KEEPALIVE_INTERVAL` (default `30`): SSH keepalive interval.
 - `SSH_CONNECT_MAX_RETRIES` (default `3`): retries per SSH hop.
 - `SSH_CONNECT_RETRY_DELAY_SECONDS` (default `2`): delay between SSH retries.
+- `SSH_POOL_MAX_CONNS` (default `64`): maximum pooled SSH connections (per bastion chain).
+- `SSH_POOL_IDLE_TIMEOUT_SECONDS` (default `900`): close pooled SSH connections idle for this duration.
+- `SSH_POOL_KEEPALIVE_INTERVAL_SECONDS` (default `30`): interval for pooled SSH keepalive probes (0 disables).
+- `SSH_POOL_KEEPALIVE_TIMEOUT_MS` (default `500`): timeout for a single pooled SSH keepalive probe.
 - CLI-only: `CLI_MODE` (`false`) to force CLI client mode; use `--server` flag for target URL.
 
 Key flags (see `./bastion --help` for full list):
@@ -113,6 +117,7 @@ Key flags (see `./bastion --help` for full list):
 - `--server` target server URL for CLI mode.
 - `--max-session-connections` per-mapping connection cap.
 - `--max-http-logs` in-memory HTTP log cap.
+- `--ssh-pool-max-conns`, `--ssh-pool-idle-timeout-seconds`, `--ssh-pool-keepalive-interval-seconds`, `--ssh-pool-keepalive-timeout-ms` SSH pool lifecycle settings.
 - `--version` show build/version info and exit.
 
 ## API Endpoints
@@ -235,6 +240,10 @@ CLI 模式：`./bastion --cli --server http://your-server:7788`
 - `SSH_KEEPALIVE_INTERVAL`（默认 `30`）：SSH keepalive 间隔。
 - `SSH_CONNECT_MAX_RETRIES`（默认 `3`）：SSH 每跳重试次数。
 - `SSH_CONNECT_RETRY_DELAY_SECONDS`（默认 `2`）：SSH 重试间隔秒数。
+- `SSH_POOL_MAX_CONNS`（默认 `64`）：SSH 连接池最大连接数（按 bastion chain 计）。
+- `SSH_POOL_IDLE_TIMEOUT_SECONDS`（默认 `900`）：空闲超过该秒数的池连接将被主动关闭。
+- `SSH_POOL_KEEPALIVE_INTERVAL_SECONDS`（默认 `30`）：池连接 keepalive 探测间隔（0 表示禁用）。
+- `SSH_POOL_KEEPALIVE_TIMEOUT_MS`（默认 `500`）：单次池连接 keepalive 探测超时（毫秒）。
 - CLI：`CLI_MODE`（默认 `false`）强制使用 CLI 客户端模式，目标地址使用 `--server`。
 
 常用标志：
@@ -247,6 +256,7 @@ CLI 模式：`./bastion --cli --server http://your-server:7788`
 - `--server`：CLI 模式下的目标服务器地址。
 - `--max-session-connections`：单映射最大连接数。
 - `--max-http-logs`：HTTP 日志内存上限。
+- `--ssh-pool-max-conns` / `--ssh-pool-idle-timeout-seconds` / `--ssh-pool-keepalive-interval-seconds` / `--ssh-pool-keepalive-timeout-ms`：SSH 连接池生命周期设置。
 - `--version`：输出版本/构建信息后退出。
 
 ### API

--- a/core/forwarder.go
+++ b/core/forwarder.go
@@ -583,13 +583,7 @@ func (s *BaseSession) dialWithRetry(remoteAddr, clientAddr, bastionChain string)
 			time.Sleep(retryDelay)
 		}
 
-		sshClient, err := Pool.GetConnection(s.Bastions)
-		if err != nil {
-			lastErr = fmt.Errorf("SSH connection failed: %w", err)
-			continue
-		}
-
-		remoteConn, err := sshClient.Dial("tcp", remoteAddr)
+		remoteConn, err := Pool.Dial(s.Bastions, "tcp", remoteAddr)
 		if err != nil {
 			lastErr = fmt.Errorf("dial failed: %w", err)
 			continue

--- a/core/pool.go
+++ b/core/pool.go
@@ -3,31 +3,90 @@ package core
 import (
 	"bastion/config"
 	"bastion/models"
+	"errors"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/crypto/ssh"
 )
 
-// SSHConnectionPool maintains SSH connections
+type sshClient interface {
+	Dial(network, addr string) (net.Conn, error)
+	SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error)
+	Close() error
+}
+
+type pooledSSHClient struct {
+	client          sshClient
+	createdAt       time.Time
+	lastUsedAt      time.Time
+	lastKeepaliveAt time.Time
+	activeConnCount int
+}
+
+// SSHConnectionPool maintains reusable SSH connections keyed by bastion chain.
 type SSHConnectionPool struct {
-	pool map[string]*ssh.Client
-	mu   sync.RWMutex
+	mu          sync.Mutex
+	pool        map[string]*pooledSSHClient
+	createChain func([]models.Bastion) (sshClient, error)
+
+	housekeepingOnce sync.Once
+	stopOnce         sync.Once
+	stopCh           chan struct{}
+
+	keepaliveFailuresTotal uint64
+	idleClosedTotal        uint64
 }
 
 var Pool *SSHConnectionPool
 
 func init() {
-	Pool = &SSHConnectionPool{
-		pool: make(map[string]*ssh.Client),
-	}
+	Pool = NewSSHConnectionPool()
 }
 
-// getChainKey builds a unique key for a bastion chain
+// NewSSHConnectionPool constructs a pool instance.
+func NewSSHConnectionPool() *SSHConnectionPool {
+	p := &SSHConnectionPool{
+		pool:   make(map[string]*pooledSSHClient),
+		stopCh: make(chan struct{}),
+	}
+	p.createChain = p.createSSHChain
+	return p
+}
+
+// StartHousekeeping starts periodic keepalive probing and idle connection sweeping.
+// It is safe to call multiple times.
+func (p *SSHConnectionPool) StartHousekeeping() {
+	p.housekeepingOnce.Do(func() {
+		go func() {
+			ticker := time.NewTicker(10 * time.Second)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-p.stopCh:
+					return
+				case <-ticker.C:
+					p.housekeep(time.Now())
+				}
+			}
+		}()
+	})
+}
+
+func (p *SSHConnectionPool) stopHousekeeping() {
+	p.stopOnce.Do(func() {
+		close(p.stopCh)
+	})
+}
+
+// getChainKey builds a unique key for a bastion chain.
 func (p *SSHConnectionPool) getChainKey(bastions []models.Bastion) string {
 	names := make([]string, len(bastions))
 	for i, b := range bastions {
@@ -36,66 +95,400 @@ func (p *SSHConnectionPool) getChainKey(bastions []models.Bastion) string {
 	return strings.Join(names, "->")
 }
 
-// GetConnection returns an existing SSH chain or creates one
-func (p *SSHConnectionPool) GetConnection(bastions []models.Bastion) (*ssh.Client, error) {
+// Dial opens a tunneled TCP connection through the bastion chain using the pooled SSH client.
+// The returned net.Conn tracks active usage so the pool can safely reclaim idle clients.
+func (p *SSHConnectionPool) Dial(bastions []models.Bastion, network, addr string) (net.Conn, error) {
+	key := p.getChainKey(bastions)
+
+	entry, err := p.getOrCreateHealthy(key, bastions)
+	if err != nil {
+		return nil, err
+	}
+
+	p.incActive(key, entry, time.Now())
+	conn, dialErr := entry.client.Dial(network, addr)
+	if dialErr != nil {
+		p.decActive(key, entry, time.Now())
+		return nil, dialErr
+	}
+
+	return &pooledConn{
+		Conn: conn,
+		release: func() {
+			p.decActive(key, entry, time.Now())
+		},
+	}, nil
+}
+
+// GetConnection returns an SSH chain client, creating it if needed.
+// Prefer Dial for forwarding paths so the pool can track active usage.
+func (p *SSHConnectionPool) GetConnection(bastions []models.Bastion) (sshClient, error) {
+	key := p.getChainKey(bastions)
+	entry, err := p.getOrCreateHealthy(key, bastions)
+	if err != nil {
+		return nil, err
+	}
+	return entry.client, nil
+}
+
+func (p *SSHConnectionPool) getOrCreateHealthy(key string, bastions []models.Bastion) (*pooledSSHClient, error) {
 	if len(bastions) == 0 {
 		return nil, fmt.Errorf("empty bastion chain")
 	}
 
-	key := p.getChainKey(bastions)
+	now := time.Now()
+	keepaliveInterval := time.Duration(config.Settings.SSHPoolKeepaliveIntervalSeconds) * time.Second
+	keepaliveTimeout := time.Duration(config.Settings.SSHPoolKeepaliveTimeoutMS) * time.Millisecond
 
-	// First try read lock for existing connection
-	p.mu.RLock()
-	conn, exists := p.pool[key]
-	p.mu.RUnlock()
-
-	if exists {
-		// Health-check outside lock to avoid holding read lock too long
-		if p.isConnectionHealthy(conn) {
-			return conn, nil
+	for {
+		p.mu.Lock()
+		entry := p.pool[key]
+		var active int
+		var lastKeepalive time.Time
+		if entry != nil {
+			entry.lastUsedAt = now
+			active = entry.activeConnCount
+			lastKeepalive = entry.lastKeepaliveAt
 		}
-		// Unhealthy connection; rebuild
-	}
+		p.mu.Unlock()
 
-	// Rebuild connection with write lock
+		if entry != nil {
+			if keepaliveInterval > 0 && now.Sub(lastKeepalive) >= keepaliveInterval && active == 0 {
+				if err := sendKeepalive(entry.client, keepaliveTimeout); err != nil {
+					atomic.AddUint64(&p.keepaliveFailuresTotal, 1)
+					if config.Settings.LogLevel == "DEBUG" {
+						log.Printf("SSH keepalive failed for chain %s: %v", key, err)
+					}
+					p.RemoveConnectionByKey(key)
+					continue
+				}
+				p.updateKeepalive(key, entry, now)
+			}
+
+			return entry, nil
+		}
+
+		created, err := p.createAndStore(key, bastions, now)
+		if err != nil {
+			return nil, err
+		}
+		return created, nil
+	}
+}
+
+func (p *SSHConnectionPool) createAndStore(key string, bastions []models.Bastion, now time.Time) (*pooledSSHClient, error) {
+	maxConns := config.Settings.SSHPoolMaxConns
+	var evicted []sshClient
+
 	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	// Double-check in case another goroutine rebuilt it
-	if conn, exists := p.pool[key]; exists {
-		// Re-verify health
-		if p.isConnectionHealthy(conn) {
-			return conn, nil
-		}
-		// Connection is dead; clean up
-		log.Printf("Connection for chain %s is closed, cleaning up", key)
-		conn.Close()
-		delete(p.pool, key)
+	if existing := p.pool[key]; existing != nil {
+		p.mu.Unlock()
+		return existing, nil
 	}
 
-	// Create new connection
+	if maxConns > 0 && len(p.pool) >= maxConns {
+		evicted = p.evictIdleLocked(now, len(p.pool)-maxConns+1)
+		if len(p.pool) >= maxConns {
+			p.mu.Unlock()
+			for _, c := range evicted {
+				_ = c.Close()
+			}
+			return nil, fmt.Errorf("ssh pool capacity reached (SSH_POOL_MAX_CONNS=%d)", maxConns)
+		}
+	}
+	p.mu.Unlock()
+
+	for _, c := range evicted {
+		_ = c.Close()
+	}
+
 	log.Printf("Creating new SSH tunnel chain for: %s", key)
-	conn, err := p.createChain(bastions)
+	client, err := p.createChain(bastions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to establish SSH chain: %w", err)
 	}
 
-	p.pool[key] = conn
-	return conn, nil
-}
-
-// isConnectionHealthy verifies the connection via a lightweight session
-func (p *SSHConnectionPool) isConnectionHealthy(conn *ssh.Client) bool {
-	session, err := conn.NewSession()
-	if err != nil {
-		return false
+	entry := &pooledSSHClient{
+		client:          client,
+		createdAt:       now,
+		lastUsedAt:      now,
+		lastKeepaliveAt: now,
 	}
-	session.Close()
-	return true
+
+	p.mu.Lock()
+	if existing := p.pool[key]; existing != nil {
+		p.mu.Unlock()
+		_ = client.Close()
+		return existing, nil
+	}
+	p.pool[key] = entry
+	p.mu.Unlock()
+
+	return entry, nil
 }
 
-// createChain builds the SSH chain with retry logic
-func (p *SSHConnectionPool) createChain(bastions []models.Bastion) (*ssh.Client, error) {
+func (p *SSHConnectionPool) evictIdleLocked(now time.Time, need int) []sshClient {
+	if need <= 0 {
+		return nil
+	}
+
+	type candidate struct {
+		key     string
+		entry   *pooledSSHClient
+		lastUse time.Time
+	}
+
+	candidates := make([]candidate, 0, len(p.pool))
+	for k, e := range p.pool {
+		if e == nil || e.activeConnCount != 0 {
+			continue
+		}
+		candidates = append(candidates, candidate{key: k, entry: e, lastUse: e.lastUsedAt})
+	}
+
+	// Sort by last used (oldest first).
+	for i := 0; i < len(candidates); i++ {
+		for j := i + 1; j < len(candidates); j++ {
+			if candidates[j].lastUse.Before(candidates[i].lastUse) {
+				candidates[i], candidates[j] = candidates[j], candidates[i]
+			}
+		}
+	}
+
+	evicted := make([]sshClient, 0, need)
+	for _, cand := range candidates {
+		if len(evicted) >= need {
+			break
+		}
+		delete(p.pool, cand.key)
+		evicted = append(evicted, cand.entry.client)
+		log.Printf("Evicting idle SSH connection due to pool capacity: %s", cand.key)
+		atomic.AddUint64(&p.idleClosedTotal, 1)
+	}
+
+	_ = now // timestamp available for future debugging
+	return evicted
+}
+
+func (p *SSHConnectionPool) updateKeepalive(key string, entry *pooledSSHClient, now time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.pool[key] != entry {
+		return
+	}
+	entry.lastKeepaliveAt = now
+}
+
+func (p *SSHConnectionPool) incActive(key string, entry *pooledSSHClient, now time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.pool[key] != entry {
+		return
+	}
+	entry.activeConnCount++
+	entry.lastUsedAt = now
+}
+
+func (p *SSHConnectionPool) decActive(key string, entry *pooledSSHClient, now time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.pool[key] != entry {
+		return
+	}
+	if entry.activeConnCount > 0 {
+		entry.activeConnCount--
+	}
+	entry.lastUsedAt = now
+}
+
+func (p *SSHConnectionPool) housekeep(now time.Time) {
+	idleTimeout := time.Duration(config.Settings.SSHPoolIdleTimeoutSeconds) * time.Second
+	keepaliveInterval := time.Duration(config.Settings.SSHPoolKeepaliveIntervalSeconds) * time.Second
+	keepaliveTimeout := time.Duration(config.Settings.SSHPoolKeepaliveTimeoutMS) * time.Millisecond
+
+	var idleToClose []sshClient
+	var keepaliveCandidates []struct {
+		key    string
+		entry  *pooledSSHClient
+		client sshClient
+	}
+
+	p.mu.Lock()
+	for key, entry := range p.pool {
+		if entry == nil {
+			continue
+		}
+
+		if idleTimeout > 0 && entry.activeConnCount == 0 && now.Sub(entry.lastUsedAt) >= idleTimeout {
+			if config.Settings.LogLevel == "DEBUG" {
+				log.Printf("Closing idle SSH connection: %s (idle=%s)", key, now.Sub(entry.lastUsedAt).Truncate(time.Second))
+			}
+			delete(p.pool, key)
+			idleToClose = append(idleToClose, entry.client)
+			atomic.AddUint64(&p.idleClosedTotal, 1)
+			continue
+		}
+
+		if keepaliveInterval > 0 && now.Sub(entry.lastKeepaliveAt) >= keepaliveInterval {
+			keepaliveCandidates = append(keepaliveCandidates, struct {
+				key    string
+				entry  *pooledSSHClient
+				client sshClient
+			}{key: key, entry: entry, client: entry.client})
+		}
+	}
+	p.mu.Unlock()
+
+	for _, c := range idleToClose {
+		_ = c.Close()
+	}
+
+	for _, cand := range keepaliveCandidates {
+		if err := sendKeepalive(cand.client, keepaliveTimeout); err != nil {
+			atomic.AddUint64(&p.keepaliveFailuresTotal, 1)
+			if config.Settings.LogLevel == "DEBUG" {
+				log.Printf("SSH keepalive failed for chain %s: %v", cand.key, err)
+			}
+
+			// Only remove/close when no active conns to avoid killing in-flight channels.
+			var toClose sshClient
+			p.mu.Lock()
+			current := p.pool[cand.key]
+			if current != nil && current == cand.entry && current.activeConnCount == 0 {
+				delete(p.pool, cand.key)
+				toClose = current.client
+			} else if current != nil && current == cand.entry {
+				current.lastKeepaliveAt = now // throttle repeated probes on broken conns
+			}
+			p.mu.Unlock()
+
+			if toClose != nil {
+				_ = toClose.Close()
+			}
+			continue
+		}
+
+		p.updateKeepalive(cand.key, cand.entry, now)
+	}
+}
+
+func sendKeepalive(client sshClient, timeout time.Duration) error {
+	if client == nil {
+		return errors.New("nil ssh client")
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := client.SendRequest("keepalive@openssh.com", true, nil)
+		done <- err
+	}()
+
+	if timeout <= 0 {
+		return <-done
+	}
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		return errors.New("keepalive timeout")
+	}
+}
+
+type pooledConn struct {
+	net.Conn
+	once    sync.Once
+	release func()
+}
+
+func (c *pooledConn) Close() error {
+	c.once.Do(func() {
+		if c.release != nil {
+			c.release()
+		}
+	})
+	return c.Conn.Close()
+}
+
+// RemoveConnection removes a specific connection by chain.
+func (p *SSHConnectionPool) RemoveConnection(bastions []models.Bastion) {
+	if len(bastions) == 0 {
+		return
+	}
+	p.RemoveConnectionByKey(p.getChainKey(bastions))
+}
+
+func (p *SSHConnectionPool) RemoveConnectionByKey(key string) {
+	var toClose sshClient
+
+	p.mu.Lock()
+	entry, exists := p.pool[key]
+	if exists {
+		delete(p.pool, key)
+		toClose = entry.client
+	}
+	p.mu.Unlock()
+
+	if exists {
+		log.Printf("Removing connection: %s", key)
+		_ = toClose.Close()
+	}
+}
+
+// CloseAll closes all pooled connections and stops housekeeping.
+func (p *SSHConnectionPool) CloseAll() {
+	p.stopHousekeeping()
+
+	p.mu.Lock()
+	connsToClose := make(map[string]sshClient, len(p.pool))
+	for key, conn := range p.pool {
+		if conn != nil {
+			connsToClose[key] = conn.client
+		}
+	}
+	p.pool = make(map[string]*pooledSSHClient)
+	p.mu.Unlock()
+
+	for key, conn := range connsToClose {
+		log.Printf("Closing connection: %s", key)
+		if err := conn.Close(); err != nil {
+			log.Printf("Error closing connection %s: %v", key, err)
+		}
+	}
+}
+
+// SSHPoolConnections returns the current number of pooled SSH clients.
+func (p *SSHConnectionPool) SSHPoolConnections() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.pool)
+}
+
+// SSHPoolActiveConns returns the count of in-flight net.Conns opened via the pool.
+func (p *SSHConnectionPool) SSHPoolActiveConns() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	total := 0
+	for _, entry := range p.pool {
+		if entry != nil {
+			total += entry.activeConnCount
+		}
+	}
+	return total
+}
+
+// SSHKeepaliveFailuresTotal returns the total number of keepalive failures observed.
+func (p *SSHConnectionPool) SSHKeepaliveFailuresTotal() uint64 {
+	return atomic.LoadUint64(&p.keepaliveFailuresTotal)
+}
+
+// SSHIdleClosedTotal returns the total number of pooled SSH connections closed due to idleness or eviction.
+func (p *SSHConnectionPool) SSHIdleClosedTotal() uint64 {
+	return atomic.LoadUint64(&p.idleClosedTotal)
+}
+
+// createSSHChain builds the SSH chain with retry logic.
+func (p *SSHConnectionPool) createSSHChain(bastions []models.Bastion) (sshClient, error) {
 	var conn *ssh.Client
 	var err error
 	maxRetries := 3
@@ -125,7 +518,7 @@ func (p *SSHConnectionPool) createChain(bastions []models.Bastion) (*ssh.Client,
 		// Ensure at least one auth method
 		if len(sshConfig.Auth) == 0 {
 			if conn != nil {
-				conn.Close()
+				_ = conn.Close()
 			}
 			return nil, fmt.Errorf("no authentication method configured for %s", b.Name)
 		}
@@ -157,7 +550,7 @@ func (p *SSHConnectionPool) createChain(bastions []models.Bastion) (*ssh.Client,
 
 				ncc, chans, reqs, err := ssh.NewClientConn(netConn, addr, sshConfig)
 				if err != nil {
-					netConn.Close()
+					_ = netConn.Close()
 					lastErr = err
 					continue
 				}
@@ -169,7 +562,7 @@ func (p *SSHConnectionPool) createChain(bastions []models.Bastion) (*ssh.Client,
 
 		if lastErr != nil {
 			if conn != nil {
-				conn.Close()
+				_ = conn.Close()
 			}
 			return nil, fmt.Errorf("failed to connect to %s after %d attempts: %w", b.Name, maxRetries, lastErr)
 		}
@@ -180,7 +573,7 @@ func (p *SSHConnectionPool) createChain(bastions []models.Bastion) (*ssh.Client,
 	return conn, nil
 }
 
-// loadPrivateKey loads a private key (optionally encrypted)
+// loadPrivateKey loads a private key (optionally encrypted).
 func loadPrivateKey(path, passphrase string) (ssh.Signer, error) {
 	// Expand ~ to user home
 	if strings.HasPrefix(path, "~/") {
@@ -203,47 +596,4 @@ func loadPrivateKey(path, passphrase string) (ssh.Signer, error) {
 	}
 
 	return signer, err
-}
-
-// CloseAll closes all pooled connections
-func (p *SSHConnectionPool) CloseAll() {
-	p.mu.Lock()
-	// Copy connections to avoid slow operations under lock
-	connsToClose := make(map[string]*ssh.Client, len(p.pool))
-	for key, conn := range p.pool {
-		connsToClose[key] = conn
-	}
-	// Clear pool
-	p.pool = make(map[string]*ssh.Client)
-	p.mu.Unlock()
-
-	// Close connections outside lock to avoid blocking others
-	for key, conn := range connsToClose {
-		log.Printf("Closing connection: %s", key)
-		if err := conn.Close(); err != nil {
-			log.Printf("Error closing connection %s: %v", key, err)
-		}
-	}
-}
-
-// RemoveConnection removes a specific connection
-func (p *SSHConnectionPool) RemoveConnection(bastions []models.Bastion) {
-	if len(bastions) == 0 {
-		return
-	}
-
-	key := p.getChainKey(bastions)
-
-	p.mu.Lock()
-	conn, exists := p.pool[key]
-	if exists {
-		delete(p.pool, key)
-	}
-	p.mu.Unlock()
-
-	// Close connection outside the lock
-	if exists {
-		log.Printf("Removing connection: %s", key)
-		conn.Close()
-	}
 }

--- a/core/pool_test.go
+++ b/core/pool_test.go
@@ -1,0 +1,187 @@
+package core
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"bastion/config"
+	"bastion/models"
+)
+
+type fakeSSHClient struct {
+	sendErr error
+	dialErr error
+	closed  bool
+}
+
+func (f *fakeSSHClient) Dial(network, addr string) (net.Conn, error) {
+	if f.dialErr != nil {
+		return nil, f.dialErr
+	}
+	c1, c2 := net.Pipe()
+	_ = c2.Close()
+	return c1, nil
+}
+
+func (f *fakeSSHClient) SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+	return false, nil, f.sendErr
+}
+
+func (f *fakeSSHClient) Close() error {
+	f.closed = true
+	return nil
+}
+
+func TestSSHConnectionPool_Housekeep_IdleClose(t *testing.T) {
+	oldIdle := config.Settings.SSHPoolIdleTimeoutSeconds
+	oldKeepalive := config.Settings.SSHPoolKeepaliveIntervalSeconds
+	t.Cleanup(func() {
+		config.Settings.SSHPoolIdleTimeoutSeconds = oldIdle
+		config.Settings.SSHPoolKeepaliveIntervalSeconds = oldKeepalive
+	})
+	config.Settings.SSHPoolIdleTimeoutSeconds = 10
+	config.Settings.SSHPoolKeepaliveIntervalSeconds = 0
+
+	pool := NewSSHConnectionPool()
+	pool.createChain = func(_ []models.Bastion) (sshClient, error) {
+		return &fakeSSHClient{}, nil
+	}
+
+	now := time.Now()
+	_, err := pool.GetConnection([]models.Bastion{{Name: "b1"}})
+	if err != nil {
+		t.Fatalf("GetConnection: %v", err)
+	}
+
+	pool.mu.Lock()
+	entry := pool.pool["b1"]
+	entry.lastUsedAt = now.Add(-time.Hour)
+	pool.mu.Unlock()
+
+	pool.housekeep(now)
+
+	if got := pool.SSHPoolConnections(); got != 0 {
+		t.Fatalf("expected pool empty, got %d", got)
+	}
+	if got := pool.SSHIdleClosedTotal(); got != 1 {
+		t.Fatalf("expected idle_closed_total=1, got %d", got)
+	}
+}
+
+func TestSSHConnectionPool_Housekeep_DoesNotCloseActive(t *testing.T) {
+	oldIdle := config.Settings.SSHPoolIdleTimeoutSeconds
+	oldKeepalive := config.Settings.SSHPoolKeepaliveIntervalSeconds
+	t.Cleanup(func() {
+		config.Settings.SSHPoolIdleTimeoutSeconds = oldIdle
+		config.Settings.SSHPoolKeepaliveIntervalSeconds = oldKeepalive
+	})
+	config.Settings.SSHPoolIdleTimeoutSeconds = 10
+	config.Settings.SSHPoolKeepaliveIntervalSeconds = 0
+
+	pool := NewSSHConnectionPool()
+	pool.createChain = func(_ []models.Bastion) (sshClient, error) {
+		return &fakeSSHClient{}, nil
+	}
+
+	now := time.Now()
+	_, err := pool.GetConnection([]models.Bastion{{Name: "b1"}})
+	if err != nil {
+		t.Fatalf("GetConnection: %v", err)
+	}
+
+	pool.mu.Lock()
+	entry := pool.pool["b1"]
+	entry.lastUsedAt = now.Add(-time.Hour)
+	entry.activeConnCount = 1
+	pool.mu.Unlock()
+
+	pool.housekeep(now)
+
+	if got := pool.SSHPoolConnections(); got != 1 {
+		t.Fatalf("expected pool size 1, got %d", got)
+	}
+}
+
+func TestSSHConnectionPool_Housekeep_KeepaliveFailureRemovesIdle(t *testing.T) {
+	oldIdle := config.Settings.SSHPoolIdleTimeoutSeconds
+	oldKeepalive := config.Settings.SSHPoolKeepaliveIntervalSeconds
+	oldTimeout := config.Settings.SSHPoolKeepaliveTimeoutMS
+	t.Cleanup(func() {
+		config.Settings.SSHPoolIdleTimeoutSeconds = oldIdle
+		config.Settings.SSHPoolKeepaliveIntervalSeconds = oldKeepalive
+		config.Settings.SSHPoolKeepaliveTimeoutMS = oldTimeout
+	})
+	config.Settings.SSHPoolIdleTimeoutSeconds = 0
+	config.Settings.SSHPoolKeepaliveIntervalSeconds = 1
+	config.Settings.SSHPoolKeepaliveTimeoutMS = 0
+
+	pool := NewSSHConnectionPool()
+	pool.createChain = func(_ []models.Bastion) (sshClient, error) {
+		return &fakeSSHClient{sendErr: errors.New("keepalive failed")}, nil
+	}
+
+	now := time.Now()
+	_, err := pool.GetConnection([]models.Bastion{{Name: "b1"}})
+	if err != nil {
+		t.Fatalf("GetConnection: %v", err)
+	}
+
+	pool.mu.Lock()
+	entry := pool.pool["b1"]
+	entry.lastKeepaliveAt = now.Add(-time.Minute)
+	pool.mu.Unlock()
+
+	pool.housekeep(now)
+
+	if got := pool.SSHPoolConnections(); got != 0 {
+		t.Fatalf("expected pool empty, got %d", got)
+	}
+	if got := pool.SSHKeepaliveFailuresTotal(); got != 1 {
+		t.Fatalf("expected keepalive_failures_total=1, got %d", got)
+	}
+}
+
+func TestSSHConnectionPool_Capacity_EvictsIdleOrErrorsWhenAllActive(t *testing.T) {
+	oldMax := config.Settings.SSHPoolMaxConns
+	oldKeepalive := config.Settings.SSHPoolKeepaliveIntervalSeconds
+	t.Cleanup(func() {
+		config.Settings.SSHPoolMaxConns = oldMax
+		config.Settings.SSHPoolKeepaliveIntervalSeconds = oldKeepalive
+	})
+	config.Settings.SSHPoolMaxConns = 1
+	config.Settings.SSHPoolKeepaliveIntervalSeconds = 0
+
+	pool := NewSSHConnectionPool()
+	pool.createChain = func(_ []models.Bastion) (sshClient, error) {
+		return &fakeSSHClient{}, nil
+	}
+
+	_, err := pool.GetConnection([]models.Bastion{{Name: "a"}})
+	if err != nil {
+		t.Fatalf("GetConnection a: %v", err)
+	}
+
+	pool.mu.Lock()
+	pool.pool["a"].activeConnCount = 1
+	pool.mu.Unlock()
+
+	_, err = pool.GetConnection([]models.Bastion{{Name: "b"}})
+	if err == nil {
+		t.Fatalf("expected capacity error when all conns are active")
+	}
+
+	pool.mu.Lock()
+	pool.pool["a"].activeConnCount = 0
+	pool.pool["a"].lastUsedAt = time.Now().Add(-time.Hour)
+	pool.mu.Unlock()
+
+	_, err = pool.GetConnection([]models.Bastion{{Name: "b"}})
+	if err != nil {
+		t.Fatalf("expected eviction to allow new conn: %v", err)
+	}
+	if got := pool.SSHPoolConnections(); got != 1 {
+		t.Fatalf("expected pool size 1, got %d", got)
+	}
+}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -518,6 +518,12 @@ func GetMetrics(c *gin.Context) {
 
 	metrics := gin.H{
 		"timestamp": s.timestamp,
+		"ssh_pool": gin.H{
+			"connections":        core.Pool.SSHPoolConnections(),
+			"active_conns":       core.Pool.SSHPoolActiveConns(),
+			"keepalive_failures": core.Pool.SSHKeepaliveFailuresTotal(),
+			"idle_closed_total":  core.Pool.SSHIdleClosedTotal(),
+		},
 		"sessions": gin.H{
 			"total":       s.sessionCount,
 			"connections": s.totalConnections,
@@ -589,6 +595,22 @@ func GetPrometheusMetrics(c *gin.Context) {
 	buf.WriteString("# HELP bastion_sessions_connections Active connections across sessions.\n")
 	buf.WriteString("# TYPE bastion_sessions_connections gauge\n")
 	fmt.Fprintf(&buf, "bastion_sessions_connections %d\n", s.totalConnections)
+
+	buf.WriteString("# HELP bastion_ssh_pool_connections Number of pooled SSH client connections.\n")
+	buf.WriteString("# TYPE bastion_ssh_pool_connections gauge\n")
+	fmt.Fprintf(&buf, "bastion_ssh_pool_connections %d\n", core.Pool.SSHPoolConnections())
+
+	buf.WriteString("# HELP bastion_ssh_pool_active_conns Active tunneled connections opened via the SSH pool.\n")
+	buf.WriteString("# TYPE bastion_ssh_pool_active_conns gauge\n")
+	fmt.Fprintf(&buf, "bastion_ssh_pool_active_conns %d\n", core.Pool.SSHPoolActiveConns())
+
+	buf.WriteString("# HELP bastion_ssh_pool_keepalive_failures_total Total pooled SSH keepalive probe failures.\n")
+	buf.WriteString("# TYPE bastion_ssh_pool_keepalive_failures_total counter\n")
+	fmt.Fprintf(&buf, "bastion_ssh_pool_keepalive_failures_total %d\n", core.Pool.SSHKeepaliveFailuresTotal())
+
+	buf.WriteString("# HELP bastion_ssh_pool_idle_closed_total Total pooled SSH connections closed due to idleness or eviction.\n")
+	buf.WriteString("# TYPE bastion_ssh_pool_idle_closed_total counter\n")
+	fmt.Fprintf(&buf, "bastion_ssh_pool_idle_closed_total %d\n", core.Pool.SSHIdleClosedTotal())
 
 	buf.WriteString("# HELP bastion_traffic_bytes_up_total Total uploaded bytes.\n")
 	buf.WriteString("# TYPE bastion_traffic_bytes_up_total counter\n")

--- a/main.go
+++ b/main.go
@@ -60,6 +60,9 @@ func main() {
 	// Start auditor
 	core.AuditorInstance.Start()
 
+	// Start SSH pool housekeeping (keepalive probes and idle reclamation).
+	core.Pool.StartHousekeeping()
+
 	// Initialize services
 	service.InitServices(database.DB, state.Global, core.AuditorInstance)
 


### PR DESCRIPTION
Closes #24

- Add SSH pool housekeeping (keepalive probes + idle reclamation)
- Track active tunneled conns and only reclaim when idle
- Add pool capacity limit with idle eviction
- Export Prometheus metrics for pool visibility
- Add unit tests and document new env/flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented SSH connection pooling with automatic keepalive probes and idle connection cleanup
  * Added configurable SSH pool parameters: max connections, idle timeout, and keepalive intervals
  * Exposed SSH pool metrics for monitoring connections, active connections, keepalive failures, and idle closures

* **Documentation**
  * Updated configuration documentation with new SSH pool environment variables and CLI flags

* **Tests**
  * Added comprehensive unit tests for SSH pool lifecycle and maintenance features

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->