### PR TITLE
feat(audit): async queue with backpressure and drops

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Environment variables (overridden by flags where available):
 - `AUDIT_ENABLED` (default `true`): enable HTTP audit logging.
 - `MAX_SESSION_CONNECTIONS` (default `1000`): max concurrent connections per mapping.
 - `FORWARD_BUFFER_SIZE` (default `32768`): TCP forward buffer size in bytes.
-- `AUDIT_QUEUE_SIZE` (default `1000`): audit queue length.
+- `AUDIT_QUEUE_SIZE` (default `1000`): asynchronous audit queue length; when full, audit messages are dropped to prioritize forwarding performance.
 - `MAX_HTTP_LOGS` (default `1000`): in-memory HTTP log cap.
 - `HTTP_PAIR_CLEANUP_INTERVAL_MINUTES` (default `5`): stale HTTP pair cleanup interval.
 - `HTTP_PAIR_MAX_AGE_MINUTES` (default `10`): max age before pairing is considered stale.
@@ -225,7 +225,7 @@ CLI 模式：`./bastion --cli --server http://your-server:7788`
 - `AUDIT_ENABLED`（默认 `true`）：启用 HTTP 审计日志。
 - `MAX_SESSION_CONNECTIONS`（默认 `1000`）：单映射最大并发连接数。
 - `FORWARD_BUFFER_SIZE`（默认 `32768`）：转发缓冲区大小（字节）。
-- `AUDIT_QUEUE_SIZE`（默认 `1000`）：审计队列长度。
+- `AUDIT_QUEUE_SIZE`（默认 `1000`）：异步审计队列长度；满时将丢弃审计消息以优先保障转发性能。
 - `MAX_HTTP_LOGS`（默认 `1000`）：HTTP 日志内存上限。
 - `HTTP_PAIR_CLEANUP_INTERVAL_MINUTES`（默认 `5`）：清理未配对 HTTP 请求的间隔分钟数。
 - `HTTP_PAIR_MAX_AGE_MINUTES`（默认 `10`）：未配对请求的最大保留分钟数。

--- a/core/audit_async_test.go
+++ b/core/audit_async_test.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"bastion/config"
+)
+
+func TestAuditor_EnqueueHTTPMessage_DropsWhenQueueFull(t *testing.T) {
+	oldEnabled := config.Settings.AuditEnabled
+	t.Cleanup(func() {
+		config.Settings.AuditEnabled = oldEnabled
+	})
+	config.Settings.AuditEnabled = true
+
+	a := &Auditor{
+		running:     true,
+		httpLogs:    make([]*HTTPLog, 0, 10),
+		httpLogsMap: make(map[int]*HTTPLog),
+		maxLogs:     10,
+	}
+	a.auditQueue = make(chan auditEvent, 1)
+
+	msg := &HTTPMessage{Type: HTTPRequest, Timestamp: time.Now(), Data: []byte("GET / HTTP/1.1\r\n\r\n")}
+	if ok := a.EnqueueHTTPMessage(AuditContext{}, "c", msg); !ok {
+		t.Fatalf("expected enqueue ok")
+	}
+	if ok := a.EnqueueHTTPMessage(AuditContext{}, "c", msg); ok {
+		t.Fatalf("expected enqueue to drop when full")
+	}
+	if got := a.AuditDroppedTotal(); got != 1 {
+		t.Fatalf("expected dropped_total=1, got %d", got)
+	}
+}
+
+func TestAuditor_AuditQueueProcessesMessages(t *testing.T) {
+	oldEnabled := config.Settings.AuditEnabled
+	oldQueue := config.Settings.AuditQueueSize
+	t.Cleanup(func() {
+		config.Settings.AuditEnabled = oldEnabled
+		config.Settings.AuditQueueSize = oldQueue
+	})
+	config.Settings.AuditEnabled = true
+	config.Settings.AuditQueueSize = 10
+
+	a := &Auditor{
+		httpLogs:             make([]*HTTPLog, 0, 10),
+		httpLogsMap:          make(map[int]*HTTPLog),
+		maxLogs:              10,
+		gzipDecodedBodyCache: make(map[int]*gzipDecodedBodyCacheEntry),
+	}
+	a.pairMatcher = NewHTTPPairMatcher(func(httpLog *HTTPLog) {
+		a.saveHTTPLog(httpLog)
+	})
+
+	a.running = true
+	a.startAuditQueue()
+	t.Cleanup(func() {
+		a.Stop()
+	})
+
+	connID := "127.0.0.1:1->127.0.0.1:2"
+	ctx := AuditContext{MappingID: "m", LocalPort: 7788, BastionChain: []string{"b"}}
+
+	req := &HTTPMessage{
+		Type:      HTTPRequest,
+		Timestamp: time.Now(),
+		Data:      []byte("GET /hello HTTP/1.1\r\nHost: example.com\r\n\r\n"),
+	}
+	resp := &HTTPMessage{
+		Type:      HTTPResponse,
+		Timestamp: time.Now().Add(10 * time.Millisecond),
+		Data:      []byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"),
+	}
+
+	if ok := a.EnqueueHTTPMessage(ctx, connID, req); !ok {
+		t.Fatalf("expected enqueue ok for request")
+	}
+	if ok := a.EnqueueHTTPMessage(ctx, connID, resp); !ok {
+		t.Fatalf("expected enqueue ok for response")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		_, total := a.GetHTTPLogs(1, 10)
+		if total == 1 {
+			log := a.GetHTTPLogByID(1)
+			if log == nil {
+				t.Fatalf("expected log present")
+			}
+			if log.MappingID != "m" || log.LocalPort != 7788 || len(log.BastionChain) != 1 || log.BastionChain[0] != "b" {
+				t.Fatalf("unexpected context fields: %+v", log)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("timeout waiting for audit processing")
+}

--- a/core/forwarder.go
+++ b/core/forwarder.go
@@ -523,7 +523,7 @@ func (s *BaseSession) feedHTTPParser(data []byte, direction, connID string) {
 
 	// Send complete messages to the auditor
 	for _, msg := range messages {
-		AuditorInstance.LogHTTPMessage(s.auditCtx, connID, msg)
+		AuditorInstance.EnqueueHTTPMessage(s.auditCtx, connID, msg)
 	}
 }
 
@@ -541,7 +541,7 @@ func (s *BaseSession) flushHTTPParser(direction, connID string) {
 
 	if parser != nil {
 		if msg := parser.Flush(); msg != nil {
-			AuditorInstance.LogHTTPMessage(s.auditCtx, connID, msg)
+			AuditorInstance.EnqueueHTTPMessage(s.auditCtx, connID, msg)
 		}
 	}
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -518,6 +518,11 @@ func GetMetrics(c *gin.Context) {
 
 	metrics := gin.H{
 		"timestamp": s.timestamp,
+		"audit": gin.H{
+			"queue_len":      service.GlobalServices.Audit.AuditQueueLen(),
+			"queue_capacity": service.GlobalServices.Audit.AuditQueueCap(),
+			"dropped_total":  service.GlobalServices.Audit.AuditDroppedTotal(),
+		},
 		"ssh_pool": gin.H{
 			"connections":        core.Pool.SSHPoolConnections(),
 			"active_conns":       core.Pool.SSHPoolActiveConns(),
@@ -595,6 +600,18 @@ func GetPrometheusMetrics(c *gin.Context) {
 	buf.WriteString("# HELP bastion_sessions_connections Active connections across sessions.\n")
 	buf.WriteString("# TYPE bastion_sessions_connections gauge\n")
 	fmt.Fprintf(&buf, "bastion_sessions_connections %d\n", s.totalConnections)
+
+	buf.WriteString("# HELP bastion_http_audit_queue_capacity HTTP audit queue capacity.\n")
+	buf.WriteString("# TYPE bastion_http_audit_queue_capacity gauge\n")
+	fmt.Fprintf(&buf, "bastion_http_audit_queue_capacity %d\n", service.GlobalServices.Audit.AuditQueueCap())
+
+	buf.WriteString("# HELP bastion_http_audit_queue_len Current number of buffered audit messages.\n")
+	buf.WriteString("# TYPE bastion_http_audit_queue_len gauge\n")
+	fmt.Fprintf(&buf, "bastion_http_audit_queue_len %d\n", service.GlobalServices.Audit.AuditQueueLen())
+
+	buf.WriteString("# HELP bastion_http_audit_dropped_total Total audit messages dropped due to backpressure.\n")
+	buf.WriteString("# TYPE bastion_http_audit_dropped_total counter\n")
+	fmt.Fprintf(&buf, "bastion_http_audit_dropped_total %d\n", service.GlobalServices.Audit.AuditDroppedTotal())
 
 	buf.WriteString("# HELP bastion_ssh_pool_connections Number of pooled SSH client connections.\n")
 	buf.WriteString("# TYPE bastion_ssh_pool_connections gauge\n")

--- a/service/audit_service.go
+++ b/service/audit_service.go
@@ -34,6 +34,21 @@ func (s *AuditService) GetHTTPLogPart(id int, part core.HTTPLogPart, opts core.H
 	return s.auditor.GetHTTPLogPart(id, part, opts)
 }
 
+// AuditQueueLen returns the current audit queue length.
+func (s *AuditService) AuditQueueLen() int {
+	return s.auditor.AuditQueueLen()
+}
+
+// AuditQueueCap returns the audit queue capacity.
+func (s *AuditService) AuditQueueCap() int {
+	return s.auditor.AuditQueueCap()
+}
+
+// AuditDroppedTotal returns the total count of dropped audit messages.
+func (s *AuditService) AuditDroppedTotal() uint64 {
+	return s.auditor.AuditDroppedTotal()
+}
+
 // ClearHTTPLogs removes all HTTP logs
 func (s *AuditService) ClearHTTPLogs() {
 	s.auditor.ClearHTTPLogs()


### PR DESCRIPTION
Closes #25

- Make audit pairing/storage asynchronous via bounded channel
- Non-blocking enqueue: drop audit messages when queue is full
- Export queue len/cap + dropped counter to /metrics and /api/metrics
- Document AUDIT_QUEUE_SIZE behavior and add unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP audit messages are now processed asynchronously via a configurable queue instead of synchronous processing.
  * Added monitoring metrics for audit queue: current length, total capacity, and count of dropped messages.

* **Documentation**
  * Updated configuration documentation describing audit queue sizing and behavior when the queue reaches capacity.

* **Tests**
  * Added tests validating asynchronous audit queue functionality including message handling and overflow scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->