### PR TITLE
fix(release): bump patch on chore(release)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -47,6 +47,8 @@ jobs:
             bump="minor"
           elif printf '%s\n' "$messages" | grep -Eq '^(fix|perf)(\([^)]+\))?: '; then
             bump="patch"
+          elif printf '%s\n' "$messages" | grep -Eq '^chore\(release\)(\([^)]+\))?: '; then
+            bump="patch"
           fi
 
           if [ "$bump" = "none" ]; then


### PR DESCRIPTION
Auto-release currently bumps only for feat/fix/perf/breaking. This makes `chore(release): ...` bump a patch version too, so release pipeline changes can ship a new tag and trigger GoReleaser automatically.

- Changes: treat `chore(release):` as `patch` bump.
- No other commit types affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to recognize additional commit patterns for determining version bump levels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->