### PR TITLE
fix(release): dispatch GoReleaser after tagging

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -117,7 +117,7 @@ jobs:
           git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin "$NEW_TAG"
 
-      - name: Trigger release workflow
+      - name: Trigger GoReleaser workflow
         if: steps.semver.outputs.should_release == 'true'
         shell: bash
         env:
@@ -126,4 +126,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          echo "Tag ${NEW_TAG} pushed. GoReleaser workflow will run on tag push."
+          # GitHub may suppress workflows triggered by pushes originating from other workflows (even for tags).
+          # Dispatch GoReleaser explicitly so a GitHub Release is always created for NEW_TAG.
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/goreleaser.yml/dispatches" \
+            -d "{\"ref\":\"main\",\"inputs\":{\"tag\":\"${NEW_TAG}\"}}"


### PR DESCRIPTION
Tag v1.10.1 was created but no release was generated because tag pushes originating from workflows can be suppressed by GitHub.

This PR makes `auto-release.yml` explicitly dispatch `.github/workflows/goreleaser.yml` after pushing the tag, ensuring a release is created even when the tag push event does not trigger workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation workflow to directly trigger GoReleaser via API dispatch, replacing the previous notification approach and ensuring more reliable and consistent release execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->