### PR TITLE
feat(security): fine-grained per-stage read/write timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,12 @@ Environment variables (overridden by flags where available):
 - `HTTP_GZIP_DECODE_CACHE_SECONDS` (default `60`): sliding cache TTL for decoded previews (0 disables cache).
 - `GOROUTINE_MONITOR_INTERVAL_SECONDS` (default `30`): goroutine monitor interval.
 - `GOROUTINE_WARN_THRESHOLD` (default `1000`): goroutine warning threshold.
-- `SOCKS5_HANDSHAKE_TIMEOUT_SECONDS` (default `30`): SOCKS5 handshake timeout.
+- `SOCKS5_HANDSHAKE_TIMEOUT_SECONDS` (default `30`): legacy SOCKS5 handshake timeout (kept for compatibility).
+- `SOCKS5_HANDSHAKE_READ_TIMEOUT_SECONDS` (default `30`): SOCKS5 handshake read timeout (per read).
+- `SOCKS5_HANDSHAKE_WRITE_TIMEOUT_SECONDS` (default `30`): SOCKS5 handshake write timeout (per write).
 - `SESSION_IDLE_TIMEOUT_HOURS` (default `24`): idle timeout for sessions.
+- `TRANSFER_READ_TIMEOUT_SECONDS` (default `86400`): data transfer read timeout (per read).
+- `TRANSFER_WRITE_TIMEOUT_SECONDS` (default `86400`): data transfer write timeout (per write).
 - `SSH_CONNECT_TIMEOUT` (default `15`): SSH dial timeout.
 - `SSH_KEEPALIVE_INTERVAL` (default `30`): SSH keepalive interval.
 - `SSH_CONNECT_MAX_RETRIES` (default `3`): retries per SSH hop.
@@ -119,6 +123,7 @@ Key flags (see `./bastion --help` for full list):
 - `--server` target server URL for CLI mode.
 - `--max-session-connections` per-mapping connection cap.
 - `--max-http-logs` in-memory HTTP log cap.
+- `--socks5-handshake-read-timeout-seconds`, `--socks5-handshake-write-timeout-seconds`, `--transfer-read-timeout-seconds`, `--transfer-write-timeout-seconds` fine-grained stage read/write timeouts.
 - `--ssh-pool-max-conns`, `--ssh-pool-idle-timeout-seconds`, `--ssh-pool-keepalive-interval-seconds`, `--ssh-pool-keepalive-timeout-ms` SSH pool lifecycle settings.
 - `--version` show build/version info and exit.
 
@@ -238,8 +243,12 @@ CLI 模式：`./bastion --cli --server http://your-server:7788`
 - `HTTP_GZIP_DECODE_CACHE_SECONDS`（默认 `60`）：解压预览的短缓存 TTL（滑动过期；0 表示禁用缓存）。
 - `GOROUTINE_MONITOR_INTERVAL_SECONDS`（默认 `30`）：goroutine 监控间隔。
 - `GOROUTINE_WARN_THRESHOLD`（默认 `1000`）：goroutine 警告阈值。
-- `SOCKS5_HANDSHAKE_TIMEOUT_SECONDS`（默认 `30`）：SOCKS5 握手超时。
+- `SOCKS5_HANDSHAKE_TIMEOUT_SECONDS`（默认 `30`）：旧的 SOCKS5 握手超时（为兼容保留）。
+- `SOCKS5_HANDSHAKE_READ_TIMEOUT_SECONDS`（默认 `30`）：SOCKS5 握手读超时（每次 Read 续期）。
+- `SOCKS5_HANDSHAKE_WRITE_TIMEOUT_SECONDS`（默认 `30`）：SOCKS5 握手写超时（每次 Write 续期）。
 - `SESSION_IDLE_TIMEOUT_HOURS`（默认 `24`）：会话空闲超时（小时）。
+- `TRANSFER_READ_TIMEOUT_SECONDS`（默认 `86400`）：数据转发读超时（每次 Read 续期）。
+- `TRANSFER_WRITE_TIMEOUT_SECONDS`（默认 `86400`）：数据转发写超时（每次 Write 续期）。
 - `SSH_CONNECT_TIMEOUT`（默认 `15`）：SSH 连接超时。
 - `SSH_KEEPALIVE_INTERVAL`（默认 `30`）：SSH keepalive 间隔。
 - `SSH_CONNECT_MAX_RETRIES`（默认 `3`）：SSH 每跳重试次数。
@@ -260,6 +269,7 @@ CLI 模式：`./bastion --cli --server http://your-server:7788`
 - `--server`：CLI 模式下的目标服务器地址。
 - `--max-session-connections`：单映射最大连接数。
 - `--max-http-logs`：HTTP 日志内存上限。
+- `--socks5-handshake-read-timeout-seconds` / `--socks5-handshake-write-timeout-seconds` / `--transfer-read-timeout-seconds` / `--transfer-write-timeout-seconds`：分阶段读写超时配置。
 - `--ssh-pool-max-conns` / `--ssh-pool-idle-timeout-seconds` / `--ssh-pool-keepalive-interval-seconds` / `--ssh-pool-keepalive-timeout-ms`：SSH 连接池生命周期设置。
 - `--version`：输出版本/构建信息后退出。
 

--- a/core/deadline_conn.go
+++ b/core/deadline_conn.go
@@ -1,0 +1,68 @@
+package core
+
+import (
+	"net"
+	"time"
+)
+
+// DeadlineConn wraps a net.Conn and applies per-operation read/write deadlines.
+// Each Read/Write refreshes the corresponding deadline to now+timeout when timeout > 0.
+type DeadlineConn struct {
+	conn         net.Conn
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+}
+
+// NewDeadlineConn wraps conn and applies read/write deadlines on each Read/Write.
+func NewDeadlineConn(conn net.Conn, readTimeout, writeTimeout time.Duration) *DeadlineConn {
+	return &DeadlineConn{
+		conn:         conn,
+		readTimeout:  readTimeout,
+		writeTimeout: writeTimeout,
+	}
+}
+
+// SetTimeouts updates the per-operation read/write timeouts.
+func (c *DeadlineConn) SetTimeouts(readTimeout, writeTimeout time.Duration) {
+	c.readTimeout = readTimeout
+	c.writeTimeout = writeTimeout
+}
+
+func (c *DeadlineConn) Read(p []byte) (int, error) {
+	if c.readTimeout > 0 {
+		_ = c.conn.SetReadDeadline(time.Now().Add(c.readTimeout))
+	} else {
+		_ = c.conn.SetReadDeadline(time.Time{})
+	}
+	return c.conn.Read(p)
+}
+
+func (c *DeadlineConn) Write(p []byte) (int, error) {
+	if c.writeTimeout > 0 {
+		_ = c.conn.SetWriteDeadline(time.Now().Add(c.writeTimeout))
+	} else {
+		_ = c.conn.SetWriteDeadline(time.Time{})
+	}
+	return c.conn.Write(p)
+}
+
+func (c *DeadlineConn) Close() error                       { return c.conn.Close() }
+func (c *DeadlineConn) LocalAddr() net.Addr                { return c.conn.LocalAddr() }
+func (c *DeadlineConn) RemoteAddr() net.Addr               { return c.conn.RemoteAddr() }
+func (c *DeadlineConn) SetDeadline(t time.Time) error      { return c.conn.SetDeadline(t) }
+func (c *DeadlineConn) SetReadDeadline(t time.Time) error  { return c.conn.SetReadDeadline(t) }
+func (c *DeadlineConn) SetWriteDeadline(t time.Time) error { return c.conn.SetWriteDeadline(t) }
+
+func (c *DeadlineConn) CloseWrite() error {
+	if cw, ok := c.conn.(interface{ CloseWrite() error }); ok {
+		return cw.CloseWrite()
+	}
+	return nil
+}
+
+func (c *DeadlineConn) CloseRead() error {
+	if cr, ok := c.conn.(interface{ CloseRead() error }); ok {
+		return cr.CloseRead()
+	}
+	return nil
+}

--- a/core/deadline_conn_test.go
+++ b/core/deadline_conn_test.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestDeadlineConnReadTimeout(t *testing.T) {
+	t.Parallel()
+
+	server, client := net.Pipe()
+	t.Cleanup(func() { _ = server.Close() })
+	t.Cleanup(func() { _ = client.Close() })
+
+	conn := NewDeadlineConn(server, 50*time.Millisecond, 0)
+	buf := make([]byte, 8)
+
+	start := time.Now()
+	_, err := conn.Read(buf)
+	if err == nil {
+		t.Fatalf("expected read timeout error, got nil")
+	}
+	var nerr net.Error
+	if !errors.As(err, &nerr) || !nerr.Timeout() {
+		t.Fatalf("expected net.Error timeout, got %T: %v", err, err)
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Fatalf("read took too long: %s", time.Since(start))
+	}
+}
+
+func TestDeadlineConnWriteTimeout(t *testing.T) {
+	t.Parallel()
+
+	server, client := net.Pipe()
+	t.Cleanup(func() { _ = server.Close() })
+	t.Cleanup(func() { _ = client.Close() })
+
+	conn := NewDeadlineConn(server, 0, 50*time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := conn.Write([]byte("hello"))
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("expected write timeout error, got nil")
+		}
+		var nerr net.Error
+		if !errors.As(err, &nerr) || !nerr.Timeout() {
+			t.Fatalf("expected net.Error timeout, got %T: %v", err, err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("write did not return within timeout")
+	}
+}
+
+func TestSocks5HandshakeTimeoutOnSlowClient(t *testing.T) {
+	t.Parallel()
+
+	server, client := net.Pipe()
+	t.Cleanup(func() { _ = server.Close() })
+	t.Cleanup(func() { _ = client.Close() })
+
+	conn := NewDeadlineConn(server, 50*time.Millisecond, 50*time.Millisecond)
+	handshake := &Socks5Handshake{}
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := handshake.Handshake(conn)
+		done <- err
+	}()
+
+	// Send only the SOCKS5 version byte, then stall so the header read times out.
+	_, _ = client.Write([]byte{0x05})
+	time.Sleep(120 * time.Millisecond)
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("expected timeout error, got nil")
+		}
+		var nerr net.Error
+		if !errors.As(err, &nerr) || !nerr.Timeout() {
+			t.Fatalf("expected net.Error timeout, got %T: %v", err, err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("handshake did not return within timeout")
+	}
+}


### PR DESCRIPTION
Closes #27\n\nAdds stage-specific read/write timeouts and applies them per operation to mitigate slow reads/writes and dead connections:\n- SOCKS5 handshake stage (read/write)\n- Data transfer stage for TCP tunnel / SOCKS5 / HTTP proxy (read/write)\n\nConfiguration is exposed via env vars and flags with documented defaults.