### PR TITLE
feat(proxy): hierarchical buffer pool for forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Environment variables (overridden by flags where available):
 - `SQLITE_CONN_MAX_LIFETIME_SECONDS` (default `0`): SQLite `ConnMaxLifetime` in seconds.
 - `AUDIT_ENABLED` (default `true`): enable HTTP audit logging.
 - `MAX_SESSION_CONNECTIONS` (default `1000`): max concurrent connections per mapping.
-- `FORWARD_BUFFER_SIZE` (default `32768`): TCP forward buffer size in bytes.
+- `FORWARD_BUFFER_SIZE` (default `32768`): maximum forward buffer size in bytes (adaptive pooled buffers use multiple size classes up to this value; buffers >64KiB are not pooled).
 - `AUDIT_QUEUE_SIZE` (default `1000`): asynchronous audit queue length; when full, audit messages are dropped to prioritize forwarding performance.
 - `MAX_HTTP_LOGS` (default `1000`): in-memory HTTP log cap.
 - `HTTP_PAIR_CLEANUP_INTERVAL_MINUTES` (default `5`): stale HTTP pair cleanup interval.
@@ -228,7 +228,7 @@ CLI 模式：`./bastion --cli --server http://your-server:7788`
 - `SQLITE_CONN_MAX_LIFETIME_SECONDS`（默认 `0`）：SQLite `ConnMaxLifetime`（秒）。
 - `AUDIT_ENABLED`（默认 `true`）：启用 HTTP 审计日志。
 - `MAX_SESSION_CONNECTIONS`（默认 `1000`）：单映射最大并发连接数。
-- `FORWARD_BUFFER_SIZE`（默认 `32768`）：转发缓冲区大小（字节）。
+- `FORWARD_BUFFER_SIZE`（默认 `32768`）：转发缓冲区最大大小（字节；转发会使用多档可复用 buffer，按需增长至该上限；>64KiB 的 buffer 不会进入对象池）。
 - `AUDIT_QUEUE_SIZE`（默认 `1000`）：异步审计队列长度；满时将丢弃审计消息以优先保障转发性能。
 - `MAX_HTTP_LOGS`（默认 `1000`）：HTTP 日志内存上限。
 - `HTTP_PAIR_CLEANUP_INTERVAL_MINUTES`（默认 `5`）：清理未配对 HTTP 请求的间隔分钟数。

--- a/core/hierarchical_buffer_pool.go
+++ b/core/hierarchical_buffer_pool.go
@@ -1,0 +1,129 @@
+package core
+
+import (
+	"sort"
+	"sync"
+)
+
+const (
+	minForwardBufferSize = 4 * 1024
+	midForwardBufferSize = 16 * 1024
+	maxPooledBufferSize  = 64 * 1024
+)
+
+// HierarchicalBufferPool provides reusable buffers with multiple size classes.
+// It avoids retaining oversized buffers indefinitely by refusing to pool buffers larger than maxPooledBufferSize.
+type HierarchicalBufferPool struct {
+	classes []int
+	pools   map[int]*sync.Pool
+}
+
+func NewHierarchicalBufferPool(maxSize int) *HierarchicalBufferPool {
+	maxSize = normalizeForwardBufferSize(maxSize)
+
+	classes := []int{minForwardBufferSize}
+	if maxSize >= midForwardBufferSize {
+		classes = append(classes, midForwardBufferSize)
+	}
+	pooledMax := maxSize
+	if pooledMax > maxPooledBufferSize {
+		pooledMax = maxPooledBufferSize
+	}
+	if pooledMax > midForwardBufferSize {
+		classes = append(classes, pooledMax)
+	}
+	if maxSize > pooledMax {
+		// Allow growth beyond pooled sizes, but do not pool these oversized buffers.
+		classes = append(classes, maxSize)
+	}
+	classes = uniqueSortedInts(classes)
+
+	pools := make(map[int]*sync.Pool, len(classes))
+	for _, size := range classes {
+		if size > maxPooledBufferSize {
+			continue
+		}
+		sz := size
+		pools[sz] = &sync.Pool{
+			New: func() any {
+				b := make([]byte, sz)
+				return &b
+			},
+		}
+	}
+
+	return &HierarchicalBufferPool{
+		classes: classes,
+		pools:   pools,
+	}
+}
+
+func (p *HierarchicalBufferPool) Get(size int) *[]byte {
+	size = normalizeForwardBufferSize(size)
+	if cls, ok := p.pools[size]; ok {
+		v := cls.Get()
+		if b, ok := v.(*[]byte); ok && b != nil {
+			return b
+		}
+	}
+	b := make([]byte, size)
+	return &b
+}
+
+func (p *HierarchicalBufferPool) Put(buf *[]byte) {
+	if buf == nil || *buf == nil {
+		return
+	}
+	sz := cap(*buf)
+	if sz <= 0 || sz > maxPooledBufferSize {
+		return
+	}
+	if cls, ok := p.pools[sz]; ok {
+		cls.Put(buf)
+	}
+}
+
+func (p *HierarchicalBufferPool) InitialSize() int {
+	return p.classes[0]
+}
+
+func (p *HierarchicalBufferPool) NextSize(cur int) (int, bool) {
+	cur = normalizeForwardBufferSize(cur)
+	for i := 0; i < len(p.classes)-1; i++ {
+		if p.classes[i] == cur {
+			return p.classes[i+1], true
+		}
+	}
+	return cur, false
+}
+
+func normalizeForwardBufferSize(size int) int {
+	if size <= 0 {
+		return midForwardBufferSize
+	}
+	if size < minForwardBufferSize {
+		return minForwardBufferSize
+	}
+	// Round to 4KiB boundaries for predictable pooling.
+	size = (size + minForwardBufferSize - 1) / minForwardBufferSize * minForwardBufferSize
+	if size < minForwardBufferSize {
+		return minForwardBufferSize
+	}
+	return size
+}
+
+func uniqueSortedInts(in []int) []int {
+	if len(in) == 0 {
+		return in
+	}
+	sort.Ints(in)
+	out := make([]int, 0, len(in))
+	last := -1
+	for _, v := range in {
+		if v != last {
+			out = append(out, v)
+			last = v
+		}
+	}
+	return out
+}

--- a/core/hierarchical_buffer_pool_test.go
+++ b/core/hierarchical_buffer_pool_test.go
@@ -1,0 +1,54 @@
+package core
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestHierarchicalBufferPoolClasses(t *testing.T) {
+	t.Parallel()
+
+	p := NewHierarchicalBufferPool(32 * 1024)
+	if len(p.classes) < 2 {
+		t.Fatalf("expected multiple classes, got %v", p.classes)
+	}
+	if p.InitialSize() != 4*1024 {
+		t.Fatalf("unexpected initial size: %d", p.InitialSize())
+	}
+	next, ok := p.NextSize(p.InitialSize())
+	if !ok || next <= p.InitialSize() {
+		t.Fatalf("expected next size > initial, got next=%d ok=%v", next, ok)
+	}
+}
+
+func BenchmarkForwardingBufferPoolMixed(b *testing.B) {
+	pool := NewHierarchicalBufferPool(32 * 1024)
+	sizes := []int{4 * 1024, 16 * 1024, 32 * 1024}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sz := sizes[i%len(sizes)]
+		bufPtr := pool.Get(sz)
+		buf := *bufPtr
+		buf[0] = 1
+		pool.Put(bufPtr)
+	}
+}
+
+func BenchmarkForwardingBufferPoolFixed32K(b *testing.B) {
+	var fixed sync.Pool
+	fixed.New = func() any {
+		buf := make([]byte, 32*1024)
+		return &buf
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bufPtr := fixed.Get().(*[]byte)
+		buf := *bufPtr
+		buf[0] = 1
+		fixed.Put(bufPtr)
+	}
+}

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -287,14 +287,10 @@ func (s *HTTPProxySession) pipeRaw(clientConn net.Conn, clientReader *bufio.Read
 }
 
 func (s *HTTPProxySession) copyRaw(dst net.Conn, src io.Reader, direction, connID string) {
-	bufAny := bufferPool.Get()
-	bufPtr, ok := bufAny.(*[]byte)
-	if !ok || bufPtr == nil {
-		buf := make([]byte, config.Settings.ForwardBufferSize)
-		bufPtr = &buf
-	}
+	pool := getForwardBufferPool()
+	bufPtr := pool.Get(pool.InitialSize())
 	buf := *bufPtr
-	defer bufferPool.Put(bufPtr)
+	defer pool.Put(bufPtr)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -321,6 +317,14 @@ func (s *HTTPProxySession) copyRaw(dst net.Conn, src io.Reader, direction, connI
 					return
 				}
 				written += w
+			}
+
+			if n == len(buf) {
+				if next, ok := pool.NextSize(len(buf)); ok && next > len(buf) {
+					pool.Put(bufPtr)
+					bufPtr = pool.Get(next)
+					buf = *bufPtr
+				}
 			}
 		}
 		if err != nil {


### PR DESCRIPTION
Closes #30\n\nAdds a hierarchical buffer pool for the forwarding path with multiple size classes. Buffers start small and grow when the read loop consistently fills the current buffer, improving memory efficiency under mixed small/large payload workloads. Oversized buffers (>64KiB) are not pooled to avoid long-lived retention.\n\nBenchmarks: goos: windows
goarch: amd64
pkg: bastion/core
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
BenchmarkForwardingBufferPoolMixed-16       	73467288	        16.38 ns/op	       0 B/op	       0 allocs/op
BenchmarkForwardingBufferPoolFixed32K-16    	141834514	         8.362 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	bastion/core	5.004s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Significantly expanded the configuration reference with documentation for new environment variables covering HTTP pair management, gzip decompression, goroutine monitoring, SOCKS5 handshake timeouts, session idle behavior, SSH connection pooling and retry logic, and authentication token support.

* **Refactor**
  * Improved internal buffer management through hierarchical pooling and dynamic sizing to optimize data forwarding performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->