### PR TITLE
chore(release): migrate GoReleaser config to v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: bastion
 
 before:
@@ -42,7 +44,8 @@ archives:
       - tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - README.md
       - LICENSE


### PR DESCRIPTION
Fixes #42

- Add `version: 2` to `.goreleaser.yaml` for GoReleaser v2
- Replace deprecated `archives.format_overrides.format` with `formats`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows release archive format configuration in build settings to ensure consistent packaging across releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->