### PR TITLE
refactor(api): dedupe http log part handling

### DIFF
--- a/handlers/handlers_v2.go
+++ b/handlers/handlers_v2.go
@@ -354,15 +354,8 @@ func GetHTTPLogsV2(c *gin.Context) {
 	})
 }
 
-func GetHTTPLogPartV2(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := strconv.Atoi(idStr)
-	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid id", "invalid id")
-		return
-	}
-
-	partStr := strings.TrimSpace(c.Param("part"))
+func respondHTTPLogPartV2(c *gin.Context, id int, partStr string) {
+	partStr = strings.TrimSpace(partStr)
 	if partStr == "" {
 		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid part", "invalid part")
 		return
@@ -399,6 +392,17 @@ func GetHTTPLogPartV2(c *gin.Context) {
 	okV2(c, result)
 }
 
+func GetHTTPLogPartV2(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid id", "invalid id")
+		return
+	}
+
+	respondHTTPLogPartV2(c, id, c.Param("part"))
+}
+
 func GetHTTPLogDetailV2(c *gin.Context) {
 	idStr := c.Param("id")
 	id, err := strconv.Atoi(idStr)
@@ -408,36 +412,7 @@ func GetHTTPLogDetailV2(c *gin.Context) {
 	}
 
 	if partStr := strings.TrimSpace(c.Query("part")); partStr != "" {
-		part := core.HTTPLogPart(partStr)
-
-		opts := core.HTTPLogPartOptions{}
-		if decodeStr := strings.TrimSpace(c.Query("decode")); decodeStr != "" {
-			if !strings.EqualFold(decodeStr, "gzip") {
-				errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid decode value", "invalid decode")
-				return
-			}
-			opts.DecodeGzip = true
-		}
-
-		result, err := service.GlobalServices.Audit.GetHTTPLogPart(id, part, opts)
-		if err != nil {
-			if errors.Is(err, core.ErrHTTPLogNotFound) {
-				errV2(c, http.StatusNotFound, CodeNotFound, "Log not found", "log not found")
-				return
-			}
-			if errors.Is(err, core.ErrInvalidHTTPLogPart) || errors.Is(err, core.ErrNotGzippedResponse) {
-				errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
-				return
-			}
-			if errors.Is(err, core.ErrGzipDecodeNotAllowed) {
-				errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "decode is only supported for part=response_body")
-				return
-			}
-			errV2(c, http.StatusInternalServerError, CodeInternal, "Failed to fetch log detail", err.Error())
-			return
-		}
-
-		okV2(c, result)
+		respondHTTPLogPartV2(c, id, partStr)
 		return
 	}
 


### PR DESCRIPTION
Extract shared part validation/service call/error mapping into respondHTTPLogPartV2 used by both query- and path-based handlers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal architecture of HTTP log retrieval by consolidating error handling and reducing code duplication across handlers, enhancing maintainability while preserving existing functionality and error semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->