### PR TITLE
API: Always return HTTP 200 for JSON responses

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -37,7 +37,7 @@ var shutdownMgr = &ShutdownManager{}
 func ListBastions(c *gin.Context) {
 	bastions, err := service.GlobalServices.Bastion.List()
 	if err != nil {
-		errV2(c, http.StatusInternalServerError, CodeInternal, "Internal error", err.Error())
+		errV2(c, CodeInternal, "Internal error", err.Error())
 		return
 	}
 	okV2(c, bastions)
@@ -47,13 +47,13 @@ func ListBastions(c *gin.Context) {
 func CreateBastion(c *gin.Context) {
 	var req models.BastionCreate
 	if err := c.ShouldBindJSON(&req); err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
 	bastion, err := service.GlobalServices.Bastion.Create(req)
 	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
@@ -65,32 +65,32 @@ func UpdateBastion(c *gin.Context) {
 	id := c.Param("id")
 	bastionID, err := strconv.ParseUint(id, 10, 32)
 	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid bastion ID")
+		errV2(c, CodeInvalidRequest, "Invalid request", "Invalid bastion ID")
 		return
 	}
 
 	var req models.BastionCreate
 	if err := c.ShouldBindJSON(&req); err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
 	// Enforce immutability of bastion name: mappings reference bastions by name.
 	existingBastion, err := service.GlobalServices.Bastion.Get(uint(bastionID))
 	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 	if req.Name != "" && req.Name != existingBastion.Name {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "bastion name is immutable")
+		errV2(c, CodeInvalidRequest, "Invalid request", "bastion name is immutable")
 		return
 	}
 	if req.Host != "" && req.Host != existingBastion.Host {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "bastion host is immutable")
+		errV2(c, CodeInvalidRequest, "Invalid request", "bastion host is immutable")
 		return
 	}
 	if req.Port != 0 && req.Port != existingBastion.Port {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "bastion port is immutable")
+		errV2(c, CodeInvalidRequest, "Invalid request", "bastion port is immutable")
 		return
 	}
 
@@ -104,11 +104,11 @@ func UpdateBastion(c *gin.Context) {
 
 	_, runningMappings, _, checkErr := service.GlobalServices.Bastion.CheckInUse(existingBastion.Name, running)
 	if checkErr != nil {
-		errV2(c, http.StatusInternalServerError, CodeInternal, "Internal error", checkErr.Error())
+		errV2(c, CodeInternal, "Internal error", checkErr.Error())
 		return
 	}
 	if len(runningMappings) > 0 {
-		errV2(c, http.StatusConflict, CodeConflict, "Conflict", gin.H{
+		errV2(c, CodeConflict, "Conflict", gin.H{
 			"reason":           "bastion_in_use",
 			"running_mappings": runningMappings,
 		})
@@ -117,7 +117,7 @@ func UpdateBastion(c *gin.Context) {
 
 	bastion, err := service.GlobalServices.Bastion.Update(uint(bastionID), req)
 	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
@@ -129,12 +129,12 @@ func DeleteBastion(c *gin.Context) {
 	id := c.Param("id")
 	bastionID, err := strconv.ParseUint(id, 10, 32)
 	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid bastion ID")
+		errV2(c, CodeInvalidRequest, "Invalid request", "Invalid bastion ID")
 		return
 	}
 
 	if err := service.GlobalServices.Bastion.Delete(uint(bastionID)); err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
@@ -145,7 +145,7 @@ func DeleteBastion(c *gin.Context) {
 func ListMappings(c *gin.Context) {
 	mappings, err := service.GlobalServices.Mapping.List()
 	if err != nil {
-		errV2(c, http.StatusInternalServerError, CodeInternal, "Internal error", err.Error())
+		errV2(c, CodeInternal, "Internal error", err.Error())
 		return
 	}
 	okV2(c, mappings)
@@ -155,17 +155,17 @@ func ListMappings(c *gin.Context) {
 func CreateMapping(c *gin.Context) {
 	var req models.MappingCreate
 	if err := c.ShouldBindJSON(&req); err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
 	mapping, err := service.GlobalServices.Mapping.Create(req)
 	if err != nil {
 		if errors.Is(err, service.ErrMappingAlreadyExists) {
-			errV2(c, http.StatusConflict, CodeConflict, "Conflict", "mapping already exists; use PUT /api/mappings/:id to update (stopped only)")
+			errV2(c, CodeConflict, "Conflict", "mapping already exists; use PUT /api/mappings/:id to update (stopped only)")
 			return
 		}
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
@@ -179,21 +179,21 @@ func UpdateMapping(c *gin.Context) {
 
 	var req models.MappingCreate
 	if err := c.ShouldBindJSON(&req); err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
 	mapping, err := service.GlobalServices.Mapping.Update(id, req)
 	if err != nil {
 		if errors.Is(err, service.ErrMappingRunning) {
-			errV2(c, http.StatusConflict, CodeConflict, "Conflict", "mapping is running; stop it before updating")
+			errV2(c, CodeConflict, "Conflict", "mapping is running; stop it before updating")
 			return
 		}
 		if errors.Is(err, service.ErrMappingNotFound) {
-			errV2(c, http.StatusNotFound, CodeNotFound, "Not found", err.Error())
+			errV2(c, CodeNotFound, "Not found", err.Error())
 			return
 		}
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
@@ -206,12 +206,12 @@ func DeleteMapping(c *gin.Context) {
 
 	// Disallow deleting an enabled (running) mapping to keep runtime state and DB data consistent.
 	if state.Global.SessionExists(id) {
-		errV2(c, http.StatusConflict, CodeConflict, "Conflict", "mapping is running; stop it before deleting")
+		errV2(c, CodeConflict, "Conflict", "mapping is running; stop it before deleting")
 		return
 	}
 
 	if err := service.GlobalServices.Mapping.Delete(id); err != nil {
-		errV2(c, http.StatusInternalServerError, CodeInternal, "Internal error", err.Error())
+		errV2(c, CodeInternal, "Internal error", err.Error())
 		return
 	}
 
@@ -227,9 +227,9 @@ func StartMapping(c *gin.Context) {
 		if errors.Is(err, service.ErrMappingAlreadyRunning) {
 			okV2(c, gin.H{"ok": true, "msg": "Already running"})
 		} else if errors.Is(err, service.ErrMappingNotFound) {
-			errV2(c, http.StatusNotFound, CodeNotFound, "Not found", err.Error())
+			errV2(c, CodeNotFound, "Not found", err.Error())
 		} else {
-			errV2(c, http.StatusBadGateway, CodeBadGateway, "Bad gateway", err.Error())
+			errV2(c, CodeBadGateway, "Bad gateway", err.Error())
 		}
 		return
 	}
@@ -289,13 +289,13 @@ func GetHTTPLogs(c *gin.Context) {
 		if regexStr := c.Query("regex"); regexStr != "" {
 			useRegex, err := strconv.ParseBool(regexStr)
 			if err != nil {
-				errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid regex flag")
+				errV2(c, CodeInvalidRequest, "Invalid request", "Invalid regex flag")
 				return
 			}
 			if useRegex {
 				re, err := regexp.Compile(q)
 				if err != nil {
-					errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid regex pattern")
+					errV2(c, CodeInvalidRequest, "Invalid request", "Invalid regex pattern")
 					return
 				}
 				filter.QueryRegex = re
@@ -318,7 +318,7 @@ func GetHTTPLogs(c *gin.Context) {
 	if localPortStr := strings.TrimSpace(c.Query("local_port")); localPortStr != "" {
 		p, err := strconv.Atoi(localPortStr)
 		if err != nil || p <= 0 || p > 65535 {
-			errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid local_port")
+			errV2(c, CodeInvalidRequest, "Invalid request", "Invalid local_port")
 			return
 		}
 		filter.LocalPort = &p
@@ -326,7 +326,7 @@ func GetHTTPLogs(c *gin.Context) {
 	if statusStr := strings.TrimSpace(c.Query("status")); statusStr != "" {
 		code, err := strconv.Atoi(statusStr)
 		if err != nil || code < 0 {
-			errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid status code")
+			errV2(c, CodeInvalidRequest, "Invalid request", "Invalid status code")
 			return
 		}
 		filter.StatusCode = code
@@ -351,7 +351,7 @@ func GetHTTPLogs(c *gin.Context) {
 	if sinceStr := c.Query("since"); sinceStr != "" {
 		tm, err := parseTime(sinceStr)
 		if err != nil {
-			errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid since timestamp")
+			errV2(c, CodeInvalidRequest, "Invalid request", "Invalid since timestamp")
 			return
 		}
 		filter.Since = tm
@@ -359,7 +359,7 @@ func GetHTTPLogs(c *gin.Context) {
 	if untilStr := c.Query("until"); untilStr != "" {
 		tm, err := parseTime(untilStr)
 		if err != nil {
-			errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid until timestamp")
+			errV2(c, CodeInvalidRequest, "Invalid request", "Invalid until timestamp")
 			return
 		}
 		filter.Until = tm
@@ -384,7 +384,7 @@ func GetHTTPLogDetail(c *gin.Context) {
 	idStr := c.Param("id")
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid ID")
+		errV2(c, CodeInvalidRequest, "Invalid request", "Invalid ID")
 		return
 	}
 
@@ -394,7 +394,7 @@ func GetHTTPLogDetail(c *gin.Context) {
 		opts := core.HTTPLogPartOptions{}
 		if decodeStr := strings.TrimSpace(c.Query("decode")); decodeStr != "" {
 			if !strings.EqualFold(decodeStr, "gzip") {
-				errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid decode value")
+				errV2(c, CodeInvalidRequest, "Invalid request", "Invalid decode value")
 				return
 			}
 			opts.DecodeGzip = true
@@ -403,18 +403,18 @@ func GetHTTPLogDetail(c *gin.Context) {
 		result, err := service.GlobalServices.Audit.GetHTTPLogPart(id, part, opts)
 		if err != nil {
 			if errors.Is(err, core.ErrHTTPLogNotFound) {
-				errV2(c, http.StatusNotFound, CodeNotFound, "Not found", "Log not found")
+				errV2(c, CodeNotFound, "Not found", "Log not found")
 				return
 			}
 			if errors.Is(err, core.ErrInvalidHTTPLogPart) || errors.Is(err, core.ErrNotGzippedResponse) {
-				errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+				errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 				return
 			}
 			if errors.Is(err, core.ErrGzipDecodeNotAllowed) {
-				errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "decode is only supported for part=response_body")
+				errV2(c, CodeInvalidRequest, "Invalid request", "decode is only supported for part=response_body")
 				return
 			}
-			errV2(c, http.StatusInternalServerError, CodeInternal, "Internal error", err.Error())
+			errV2(c, CodeInternal, "Internal error", err.Error())
 			return
 		}
 
@@ -424,7 +424,7 @@ func GetHTTPLogDetail(c *gin.Context) {
 
 	log := service.GlobalServices.Audit.GetHTTPLogByID(id)
 	if log == nil {
-		errV2(c, http.StatusNotFound, CodeNotFound, "Not found", "Log not found")
+		errV2(c, CodeNotFound, "Not found", "Log not found")
 		return
 	}
 
@@ -464,7 +464,7 @@ func HealthCheck(c *gin.Context) {
 
 	if !dbHealthy {
 		health["status"] = "degraded"
-		respondV2(c, http.StatusServiceUnavailable, CodeInternal, "Service degraded", health)
+		respondV2(c, CodeInternal, "Service degraded", health)
 		return
 	}
 
@@ -680,7 +680,7 @@ func GenerateShutdownCode(c *gin.Context) {
 	// Generate a 6-digit random number
 	n, err := rand.Int(rand.Reader, big.NewInt(1000000))
 	if err != nil {
-		errV2(c, http.StatusInternalServerError, CodeInternal, "Internal error", "Failed to generate code")
+		errV2(c, CodeInternal, "Internal error", "Failed to generate code")
 		return
 	}
 
@@ -700,7 +700,7 @@ func VerifyAndShutdown(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid request")
+		errV2(c, CodeInvalidRequest, "Invalid request", "Invalid request")
 		return
 	}
 
@@ -711,7 +711,7 @@ func VerifyAndShutdown(c *gin.Context) {
 
 	// Ensure a code was issued
 	if storedCode == "" {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "No shutdown code generated. Please generate one first.")
+		errV2(c, CodeInvalidRequest, "Invalid request", "No shutdown code generated. Please generate one first.")
 		return
 	}
 
@@ -720,13 +720,13 @@ func VerifyAndShutdown(c *gin.Context) {
 		shutdownMgr.mu.Lock()
 		shutdownMgr.code = ""
 		shutdownMgr.mu.Unlock()
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Shutdown code expired. Please generate a new one.")
+		errV2(c, CodeInvalidRequest, "Invalid request", "Shutdown code expired. Please generate a new one.")
 		return
 	}
 
 	// Validate the code value
 	if req.Code != storedCode {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid shutdown code")
+		errV2(c, CodeInvalidRequest, "Invalid request", "Invalid shutdown code")
 		return
 	}
 

--- a/handlers/handlers_v2.go
+++ b/handlers/handlers_v2.go
@@ -25,7 +25,7 @@ import (
 func ListBastionsV2(c *gin.Context) {
 	bastions, err := service.GlobalServices.Bastion.List()
 	if err != nil {
-		errV2(c, http.StatusInternalServerError, CodeInternal, "Failed to list bastions", err.Error())
+		errV2(c, CodeInternal, "Failed to list bastions", err.Error())
 		return
 	}
 	okV2(c, bastions)
@@ -34,13 +34,13 @@ func ListBastionsV2(c *gin.Context) {
 func CreateBastionV2(c *gin.Context) {
 	var req models.BastionCreate
 	if err := c.ShouldBindJSON(&req); err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
 	bastion, err := service.GlobalServices.Bastion.Create(req)
 	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Failed to create bastion", err.Error())
+		errV2(c, CodeInvalidRequest, "Failed to create bastion", err.Error())
 		return
 	}
 
@@ -51,31 +51,31 @@ func UpdateBastionV2(c *gin.Context) {
 	id := c.Param("id")
 	bastionID, err := strconv.ParseUint(id, 10, 32)
 	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid bastion id", "invalid bastion id")
+		errV2(c, CodeInvalidRequest, "Invalid bastion id", "invalid bastion id")
 		return
 	}
 
 	var req models.BastionCreate
 	if err := c.ShouldBindJSON(&req); err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
 	existingBastion, err := service.GlobalServices.Bastion.Get(uint(bastionID))
 	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Failed to load bastion", err.Error())
+		errV2(c, CodeInvalidRequest, "Failed to load bastion", err.Error())
 		return
 	}
 	if req.Name != "" && req.Name != existingBastion.Name {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "bastion name is immutable", "bastion name is immutable")
+		errV2(c, CodeInvalidRequest, "bastion name is immutable", "bastion name is immutable")
 		return
 	}
 	if req.Host != "" && req.Host != existingBastion.Host {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "bastion host is immutable", "bastion host is immutable")
+		errV2(c, CodeInvalidRequest, "bastion host is immutable", "bastion host is immutable")
 		return
 	}
 	if req.Port != 0 && req.Port != existingBastion.Port {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "bastion port is immutable", "bastion port is immutable")
+		errV2(c, CodeInvalidRequest, "bastion port is immutable", "bastion port is immutable")
 		return
 	}
 
@@ -88,11 +88,11 @@ func UpdateBastionV2(c *gin.Context) {
 
 	_, runningMappings, _, checkErr := service.GlobalServices.Bastion.CheckInUse(existingBastion.Name, running)
 	if checkErr != nil {
-		errV2(c, http.StatusInternalServerError, CodeInternal, "Failed to check bastion usage", checkErr.Error())
+		errV2(c, CodeInternal, "Failed to check bastion usage", checkErr.Error())
 		return
 	}
 	if len(runningMappings) > 0 {
-		respondV2(c, http.StatusConflict, CodeConflict, "Bastion is referenced by running mapping(s)", gin.H{
+		respondV2(c, CodeConflict, "Bastion is referenced by running mapping(s)", gin.H{
 			"running_mappings": runningMappings,
 		})
 		return
@@ -100,7 +100,7 @@ func UpdateBastionV2(c *gin.Context) {
 
 	bastion, err := service.GlobalServices.Bastion.Update(uint(bastionID), req)
 	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Failed to update bastion", err.Error())
+		errV2(c, CodeInvalidRequest, "Failed to update bastion", err.Error())
 		return
 	}
 	okV2(c, gin.H{"id": bastion.ID})
@@ -110,12 +110,12 @@ func DeleteBastionV2(c *gin.Context) {
 	id := c.Param("id")
 	bastionID, err := strconv.ParseUint(id, 10, 32)
 	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid bastion id", "invalid bastion id")
+		errV2(c, CodeInvalidRequest, "Invalid bastion id", "invalid bastion id")
 		return
 	}
 
 	if err := service.GlobalServices.Bastion.Delete(uint(bastionID)); err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Failed to delete bastion", err.Error())
+		errV2(c, CodeInvalidRequest, "Failed to delete bastion", err.Error())
 		return
 	}
 	okV2(c, gin.H{"ok": true})
@@ -124,7 +124,7 @@ func DeleteBastionV2(c *gin.Context) {
 func ListMappingsV2(c *gin.Context) {
 	mappings, err := service.GlobalServices.Mapping.List()
 	if err != nil {
-		errV2(c, http.StatusInternalServerError, CodeInternal, "Failed to list mappings", err.Error())
+		errV2(c, CodeInternal, "Failed to list mappings", err.Error())
 		return
 	}
 	okV2(c, mappings)
@@ -133,17 +133,17 @@ func ListMappingsV2(c *gin.Context) {
 func CreateMappingV2(c *gin.Context) {
 	var req models.MappingCreate
 	if err := c.ShouldBindJSON(&req); err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
 	mapping, err := service.GlobalServices.Mapping.Create(req)
 	if err != nil {
 		if errors.Is(err, service.ErrMappingAlreadyExists) {
-			errV2(c, http.StatusConflict, CodeConflict, "Mapping already exists", err.Error())
+			errV2(c, CodeConflict, "Mapping already exists", err.Error())
 			return
 		}
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Failed to create mapping", err.Error())
+		errV2(c, CodeInvalidRequest, "Failed to create mapping", err.Error())
 		return
 	}
 
@@ -155,21 +155,21 @@ func UpdateMappingV2(c *gin.Context) {
 
 	var req models.MappingCreate
 	if err := c.ShouldBindJSON(&req); err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+		errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
 	mapping, err := service.GlobalServices.Mapping.Update(id, req)
 	if err != nil {
 		if errors.Is(err, service.ErrMappingRunning) {
-			errV2(c, http.StatusConflict, CodeConflict, "Mapping is running", err.Error())
+			errV2(c, CodeConflict, "Mapping is running", err.Error())
 			return
 		}
 		if errors.Is(err, service.ErrMappingNotFound) {
-			errV2(c, http.StatusNotFound, CodeNotFound, "Mapping not found", err.Error())
+			errV2(c, CodeNotFound, "Mapping not found", err.Error())
 			return
 		}
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Failed to update mapping", err.Error())
+		errV2(c, CodeInvalidRequest, "Failed to update mapping", err.Error())
 		return
 	}
 
@@ -179,12 +179,12 @@ func UpdateMappingV2(c *gin.Context) {
 func DeleteMappingV2(c *gin.Context) {
 	id := c.Param("id")
 	if state.Global.SessionExists(id) {
-		errV2(c, http.StatusConflict, CodeConflict, "Mapping is running", "mapping is running")
+		errV2(c, CodeConflict, "Mapping is running", "mapping is running")
 		return
 	}
 
 	if err := service.GlobalServices.Mapping.Delete(id); err != nil {
-		errV2(c, http.StatusInternalServerError, CodeInternal, "Failed to delete mapping", err.Error())
+		errV2(c, CodeInternal, "Failed to delete mapping", err.Error())
 		return
 	}
 	okV2(c, gin.H{"ok": true})
@@ -199,13 +199,13 @@ func StartMappingV2(c *gin.Context) {
 			return
 		}
 		if errors.Is(err, service.ErrMappingNotFound) {
-			errV2(c, http.StatusNotFound, CodeNotFound, "Mapping not found", err.Error())
+			errV2(c, CodeNotFound, "Mapping not found", err.Error())
 			return
 		}
 
 		var portErr *core.PortInUseError
 		if errors.As(err, &portErr) {
-			respondV2(c, http.StatusConflict, CodeResourceBusy, "Local address is already in use", portErr.Detail)
+			respondV2(c, CodeResourceBusy, "Local address is already in use", portErr.Detail)
 			return
 		}
 		var be *core.BastionError
@@ -214,14 +214,14 @@ func StartMappingV2(c *gin.Context) {
 			if m, getErr := service.GlobalServices.Mapping.Get(id); getErr == nil {
 				addr = net.JoinHostPort(m.LocalHost, strconv.Itoa(m.LocalPort))
 			}
-			respondV2(c, http.StatusConflict, CodeResourceBusy, "Local address is already in use", gin.H{
+			respondV2(c, CodeResourceBusy, "Local address is already in use", gin.H{
 				"detail": err.Error(),
 				"addr":   addr,
 			})
 			return
 		}
 		// Keep status aligned with v1 (which uses 502 for other start failures)
-		errV2(c, http.StatusBadGateway, CodeBadGateway, "Failed to start mapping", err.Error())
+		errV2(c, CodeBadGateway, "Failed to start mapping", err.Error())
 		return
 	}
 
@@ -275,13 +275,13 @@ func GetHTTPLogsV2(c *gin.Context) {
 		if regexStr := c.Query("regex"); regexStr != "" {
 			useRegex, err := strconv.ParseBool(regexStr)
 			if err != nil {
-				errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid regex flag", "invalid regex flag")
+				errV2(c, CodeInvalidRequest, "Invalid regex flag", "invalid regex flag")
 				return
 			}
 			if useRegex {
 				re, err := regexp.Compile(q)
 				if err != nil {
-					errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid regex pattern", "invalid regex pattern")
+					errV2(c, CodeInvalidRequest, "Invalid regex pattern", "invalid regex pattern")
 					return
 				}
 				filter.QueryRegex = re
@@ -304,7 +304,7 @@ func GetHTTPLogsV2(c *gin.Context) {
 	if localPortStr := strings.TrimSpace(c.Query("local_port")); localPortStr != "" {
 		p, err := strconv.Atoi(localPortStr)
 		if err != nil || p <= 0 || p > 65535 {
-			errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid local_port", "invalid local_port")
+			errV2(c, CodeInvalidRequest, "Invalid local_port", "invalid local_port")
 			return
 		}
 		filter.LocalPort = &p
@@ -312,7 +312,7 @@ func GetHTTPLogsV2(c *gin.Context) {
 	if statusStr := strings.TrimSpace(c.Query("status")); statusStr != "" {
 		code, err := strconv.Atoi(statusStr)
 		if err != nil || code < 0 {
-			errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid status code", "invalid status")
+			errV2(c, CodeInvalidRequest, "Invalid status code", "invalid status")
 			return
 		}
 		filter.StatusCode = code
@@ -337,7 +337,7 @@ func GetHTTPLogsV2(c *gin.Context) {
 	if sinceStr := c.Query("since"); sinceStr != "" {
 		tm, err := parseTime(sinceStr)
 		if err != nil {
-			errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid since timestamp", "invalid since")
+			errV2(c, CodeInvalidRequest, "Invalid since timestamp", "invalid since")
 			return
 		}
 		filter.Since = tm
@@ -345,7 +345,7 @@ func GetHTTPLogsV2(c *gin.Context) {
 	if untilStr := c.Query("until"); untilStr != "" {
 		tm, err := parseTime(untilStr)
 		if err != nil {
-			errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid until timestamp", "invalid until")
+			errV2(c, CodeInvalidRequest, "Invalid until timestamp", "invalid until")
 			return
 		}
 		filter.Until = tm
@@ -363,7 +363,7 @@ func GetHTTPLogsV2(c *gin.Context) {
 func respondHTTPLogPartV2(c *gin.Context, id int, partStr string) {
 	partStr = strings.TrimSpace(partStr)
 	if partStr == "" {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid part", "invalid part")
+		errV2(c, CodeInvalidRequest, "Invalid part", "invalid part")
 		return
 	}
 	part := core.HTTPLogPart(partStr)
@@ -371,7 +371,7 @@ func respondHTTPLogPartV2(c *gin.Context, id int, partStr string) {
 	opts := core.HTTPLogPartOptions{}
 	if decodeStr := strings.TrimSpace(c.Query("decode")); decodeStr != "" {
 		if !strings.EqualFold(decodeStr, "gzip") {
-			errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid decode value", "invalid decode")
+			errV2(c, CodeInvalidRequest, "Invalid decode value", "invalid decode")
 			return
 		}
 		opts.DecodeGzip = true
@@ -380,18 +380,18 @@ func respondHTTPLogPartV2(c *gin.Context, id int, partStr string) {
 	result, err := service.GlobalServices.Audit.GetHTTPLogPart(id, part, opts)
 	if err != nil {
 		if errors.Is(err, core.ErrHTTPLogNotFound) {
-			errV2(c, http.StatusNotFound, CodeNotFound, "Log not found", "log not found")
+			errV2(c, CodeNotFound, "Log not found", "log not found")
 			return
 		}
 		if errors.Is(err, core.ErrInvalidHTTPLogPart) || errors.Is(err, core.ErrNotGzippedResponse) {
-			errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
+			errV2(c, CodeInvalidRequest, "Invalid request", err.Error())
 			return
 		}
 		if errors.Is(err, core.ErrGzipDecodeNotAllowed) {
-			errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "decode is only supported for part=response_body")
+			errV2(c, CodeInvalidRequest, "Invalid request", "decode is only supported for part=response_body")
 			return
 		}
-		errV2(c, http.StatusInternalServerError, CodeInternal, "Failed to fetch log detail", err.Error())
+		errV2(c, CodeInternal, "Failed to fetch log detail", err.Error())
 		return
 	}
 
@@ -402,7 +402,7 @@ func GetHTTPLogPartV2(c *gin.Context) {
 	idStr := c.Param("id")
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid id", "invalid id")
+		errV2(c, CodeInvalidRequest, "Invalid id", "invalid id")
 		return
 	}
 
@@ -413,7 +413,7 @@ func GetHTTPLogDetailV2(c *gin.Context) {
 	idStr := c.Param("id")
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid id", "invalid id")
+		errV2(c, CodeInvalidRequest, "Invalid id", "invalid id")
 		return
 	}
 
@@ -424,7 +424,7 @@ func GetHTTPLogDetailV2(c *gin.Context) {
 
 	log := service.GlobalServices.Audit.GetHTTPLogByID(id)
 	if log == nil {
-		errV2(c, http.StatusNotFound, CodeNotFound, "Log not found", "log not found")
+		errV2(c, CodeNotFound, "Log not found", "log not found")
 		return
 	}
 
@@ -451,7 +451,7 @@ func GenerateShutdownCodeV2(c *gin.Context) {
 
 	n, err := rand.Int(rand.Reader, big.NewInt(1000000))
 	if err != nil {
-		errV2(c, http.StatusInternalServerError, CodeInternal, "Failed to generate code", "Failed to generate code")
+		errV2(c, CodeInternal, "Failed to generate code", "Failed to generate code")
 		return
 	}
 
@@ -466,7 +466,7 @@ func VerifyAndShutdownV2(c *gin.Context) {
 		Code string `json:"code" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid request")
+		errV2(c, CodeInvalidRequest, "Invalid request", "Invalid request")
 		return
 	}
 
@@ -476,7 +476,7 @@ func VerifyAndShutdownV2(c *gin.Context) {
 	shutdownMgr.mu.RUnlock()
 
 	if storedCode == "" {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "No shutdown code generated", "No shutdown code generated")
+		errV2(c, CodeInvalidRequest, "No shutdown code generated", "No shutdown code generated")
 		return
 	}
 
@@ -484,12 +484,12 @@ func VerifyAndShutdownV2(c *gin.Context) {
 		shutdownMgr.mu.Lock()
 		shutdownMgr.code = ""
 		shutdownMgr.mu.Unlock()
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Shutdown code expired", "Shutdown code expired")
+		errV2(c, CodeInvalidRequest, "Shutdown code expired", "Shutdown code expired")
 		return
 	}
 
 	if req.Code != storedCode {
-		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid shutdown code", "Invalid shutdown code")
+		errV2(c, CodeInvalidRequest, "Invalid shutdown code", "Invalid shutdown code")
 		return
 	}
 
@@ -531,7 +531,7 @@ func HealthCheckV2(c *gin.Context) {
 
 	if !dbHealthy {
 		health["status"] = "degraded"
-		respondV2(c, http.StatusServiceUnavailable, CodeInternal, "Service degraded", health)
+		respondV2(c, CodeInternal, "Service degraded", health)
 		return
 	}
 

--- a/handlers/response_v2.go
+++ b/handlers/response_v2.go
@@ -22,19 +22,19 @@ const (
 	CodeInternal       = "INTERNAL_ERROR"
 )
 
-func respondV2(c *gin.Context, status int, code, message string, data any) {
+func respondV2(c *gin.Context, code, message string, data any) {
 	c.JSON(http.StatusOK, ResponseV2{Code: code, Message: message, Data: data})
 }
 
 func okV2(c *gin.Context, data any) {
-	respondV2(c, http.StatusOK, CodeOK, "OK", data)
+	respondV2(c, CodeOK, "OK", data)
 }
 
-func errV2(c *gin.Context, status int, code, message string, detail any) {
+func errV2(c *gin.Context, code, message string, detail any) {
 	// Keep the envelope stable: put free-form details into `data.detail`.
 	payload := gin.H{}
 	if detail != nil {
 		payload["detail"] = detail
 	}
-	respondV2(c, status, code, message, payload)
+	respondV2(c, code, message, payload)
 }

--- a/handlers/response_v2.go
+++ b/handlers/response_v2.go
@@ -23,7 +23,7 @@ const (
 )
 
 func respondV2(c *gin.Context, status int, code, message string, data any) {
-	c.JSON(status, ResponseV2{Code: code, Message: message, Data: data})
+	c.JSON(http.StatusOK, ResponseV2{Code: code, Message: message, Data: data})
 }
 
 func okV2(c *gin.Context, data any) {

--- a/handlers/update.go
+++ b/handlers/update.go
@@ -111,14 +111,14 @@ func CheckUpdate(c *gin.Context) {
 	release, err := fetchLatestRelease(ctx)
 	if err != nil {
 		log.Printf("update: check fetch latest release failed: %v", err)
-		c.JSON(http.StatusBadGateway, gin.H{"detail": err.Error()})
+		errV2(c, http.StatusBadGateway, CodeBadGateway, "Bad gateway", err.Error())
 		return
 	}
 
 	assetName, downloadURL, err := selectReleaseAsset(release, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		log.Printf("update: check select asset failed (tag=%s os=%s arch=%s): %v", release.TagName, runtime.GOOS, runtime.GOARCH, err)
-		c.JSON(http.StatusBadGateway, gin.H{"detail": err.Error()})
+		errV2(c, http.StatusBadGateway, CodeBadGateway, "Bad gateway", err.Error())
 		return
 	}
 
@@ -131,7 +131,7 @@ func CheckUpdate(c *gin.Context) {
 		"update: check result current=%s latest=%s available=%v asset=%s",
 		current, latest, updateAvailable, assetName,
 	)
-	c.JSON(http.StatusOK, updateCheckResponse{
+	okV2(c, updateCheckResponse{
 		CurrentVersion:  normalizeTag(current),
 		LatestVersion:   normalizeTag(latest),
 		UpdateAvailable: updateAvailable,
@@ -151,7 +151,7 @@ func GenerateUpdateCode(c *gin.Context) {
 	release, err := fetchLatestRelease(ctx)
 	if err != nil {
 		log.Printf("update: generate code fetch latest release failed: %v", err)
-		c.JSON(http.StatusBadGateway, gin.H{"detail": err.Error()})
+		errV2(c, http.StatusBadGateway, CodeBadGateway, "Bad gateway", err.Error())
 		return
 	}
 
@@ -159,14 +159,14 @@ func GenerateUpdateCode(c *gin.Context) {
 	latest := strings.TrimSpace(release.TagName)
 	if !isVersionNewer(latest, current) {
 		log.Printf("update: generate code skipped (already up to date current=%s latest=%s)", current, latest)
-		c.JSON(http.StatusBadRequest, gin.H{"detail": "already up to date"})
+		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "already up to date")
 		return
 	}
 
 	code, err := generateSixDigitCode()
 	if err != nil {
 		log.Printf("update: generate code failed: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"detail": err.Error()})
+		errV2(c, http.StatusInternalServerError, CodeInternal, "Internal error", err.Error())
 		return
 	}
 
@@ -177,7 +177,7 @@ func GenerateUpdateCode(c *gin.Context) {
 	updateMgr.mu.Unlock()
 
 	log.Printf("update: code generated (expires_at=%s)", expiresAt.UTC().Format(time.RFC3339))
-	c.JSON(http.StatusOK, updateGenerateCodeResponse{
+	okV2(c, updateGenerateCodeResponse{
 		Code:      code,
 		ExpiresAt: expiresAt.Unix(),
 	})
@@ -190,7 +190,7 @@ func GetUpdateProxy(c *gin.Context) {
 	env := readProxyEnv()
 	effective, source := chooseEffectiveProxy(manual, env)
 
-	c.JSON(http.StatusOK, updateProxyResponse{
+	okV2(c, updateProxyResponse{
 		ManualProxy:    redactProxy(manual),
 		EnvHTTPProxy:   redactProxy(env.httpProxy),
 		EnvHTTPSProxy:  redactProxy(env.httpsProxy),
@@ -205,37 +205,37 @@ func GetUpdateProxy(c *gin.Context) {
 func SetUpdateProxy(c *gin.Context) {
 	var req updateProxyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"detail": "Invalid request"})
+		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid request")
 		return
 	}
 
 	value := strings.TrimSpace(req.ProxyURL)
 	if value == "" {
 		if err := database.DeleteSetting(updateProxySettingKey); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"detail": err.Error()})
+			errV2(c, http.StatusInternalServerError, CodeInternal, "Internal error", err.Error())
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"ok": true})
+		okV2(c, gin.H{"ok": true})
 		return
 	}
 
 	u, err := url.Parse(value)
 	if err != nil || u.Scheme == "" || u.Host == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"detail": "invalid proxy url"})
+		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "invalid proxy url")
 		return
 	}
 	switch strings.ToLower(u.Scheme) {
 	case "http", "https", "socks5", "socks5h":
 	default:
-		c.JSON(http.StatusBadRequest, gin.H{"detail": "proxy url must start with http(s):// or socks5(h)://"})
+		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "proxy url must start with http(s):// or socks5(h)://")
 		return
 	}
 
 	if err := database.SetSetting(updateProxySettingKey, value); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"detail": err.Error()})
+		errV2(c, http.StatusInternalServerError, CodeInternal, "Internal error", err.Error())
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"ok": true})
+	okV2(c, gin.H{"ok": true})
 }
 
 // ApplyUpdate downloads and installs the latest release asset, then restarts via a helper process.
@@ -247,31 +247,31 @@ func ApplyUpdate(c *gin.Context) {
 	var req updateApplyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		log.Printf("update: apply invalid request: %v", err)
-		c.JSON(http.StatusBadRequest, gin.H{"detail": "Invalid request"})
+		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "Invalid request")
 		return
 	}
 	if shutdownChan == nil {
 		log.Printf("update: apply aborted (shutdown channel not set)")
-		c.JSON(http.StatusInternalServerError, gin.H{"detail": "shutdown channel is not initialized"})
+		errV2(c, http.StatusInternalServerError, CodeInternal, "Internal error", "shutdown channel is not initialized")
 		return
 	}
 	if err := verifyUpdateCode(req.Code); err != nil {
 		log.Printf("update: apply code verification failed: %v", err)
-		c.JSON(http.StatusBadRequest, gin.H{"detail": err.Error()})
+		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", err.Error())
 		return
 	}
 
 	release, err := fetchLatestRelease(ctx)
 	if err != nil {
 		log.Printf("update: apply fetch latest release failed: %v", err)
-		c.JSON(http.StatusBadGateway, gin.H{"detail": err.Error()})
+		errV2(c, http.StatusBadGateway, CodeBadGateway, "Bad gateway", err.Error())
 		return
 	}
 
 	assetName, downloadURL, err := selectReleaseAsset(release, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		log.Printf("update: apply select asset failed (tag=%s os=%s arch=%s): %v", release.TagName, runtime.GOOS, runtime.GOARCH, err)
-		c.JSON(http.StatusBadGateway, gin.H{"detail": err.Error()})
+		errV2(c, http.StatusBadGateway, CodeBadGateway, "Bad gateway", err.Error())
 		return
 	}
 
@@ -279,14 +279,14 @@ func ApplyUpdate(c *gin.Context) {
 	latest := strings.TrimSpace(release.TagName)
 	if !isVersionNewer(latest, current) {
 		log.Printf("update: apply aborted (already up to date current=%s latest=%s)", current, latest)
-		c.JSON(http.StatusBadRequest, gin.H{"detail": "already up to date"})
+		errV2(c, http.StatusBadRequest, CodeInvalidRequest, "Invalid request", "already up to date")
 		return
 	}
 
 	exePath, err := os.Executable()
 	if err != nil {
 		log.Printf("update: apply os.Executable failed: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"detail": err.Error()})
+		errV2(c, http.StatusInternalServerError, CodeInternal, "Internal error", err.Error())
 		return
 	}
 	exePath, _ = filepath.Abs(exePath)
@@ -294,7 +294,7 @@ func ApplyUpdate(c *gin.Context) {
 	tmpDir, err := os.MkdirTemp("", "bastion-update-*")
 	if err != nil {
 		log.Printf("update: apply MkdirTemp failed: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"detail": err.Error()})
+		errV2(c, http.StatusInternalServerError, CodeInternal, "Internal error", err.Error())
 		return
 	}
 
@@ -307,7 +307,7 @@ func ApplyUpdate(c *gin.Context) {
 	if err := downloadFile(ctx, downloadURL, archivePath); err != nil {
 		log.Printf("update: apply download failed (dst=%s): %v", archivePath, err)
 		_ = os.RemoveAll(tmpDir)
-		c.JSON(http.StatusBadGateway, gin.H{"detail": err.Error()})
+		errV2(c, http.StatusBadGateway, CodeBadGateway, "Bad gateway", err.Error())
 		return
 	}
 
@@ -315,7 +315,7 @@ func ApplyUpdate(c *gin.Context) {
 	if err != nil {
 		log.Printf("update: apply extract failed (archive=%s tmp=%s): %v", archivePath, tmpDir, err)
 		_ = os.RemoveAll(tmpDir)
-		c.JSON(http.StatusBadGateway, gin.H{"detail": err.Error()})
+		errV2(c, http.StatusBadGateway, CodeBadGateway, "Bad gateway", err.Error())
 		return
 	}
 	log.Printf("update: apply extracted binary=%s", newBinPath)
@@ -360,12 +360,12 @@ func ApplyUpdate(c *gin.Context) {
 	if err := cmd.Start(); err != nil {
 		log.Printf("update: apply start helper failed: %v", err)
 		_ = os.RemoveAll(tmpDir)
-		c.JSON(http.StatusInternalServerError, gin.H{"detail": err.Error()})
+		errV2(c, http.StatusInternalServerError, CodeInternal, "Internal error", err.Error())
 		return
 	}
 	log.Printf("update: apply helper started (pid=%d) helper_log=%s", cmd.Process.Pid, helperLogPath)
 
-	c.JSON(http.StatusOK, updateApplyResponse{
+	okV2(c, updateApplyResponse{
 		OK:            true,
 		TargetVersion: normalizeTag(latest),
 		Message:       "update started; restarting",


### PR DESCRIPTION
Fixes #52.

## What changed
- All JSON endpoints now respond with HTTP 200 and convey success/failure via the JSON envelope (`code`, `message`, `data`).
- `/api/v2` envelope always returns 200 via `handlers/respondV2`.
- `/api` (v1) handlers now use the same envelope helpers to avoid mixing HTTP status codes with JSON payloads.
- CLI client parses the envelope and reports non-OK `code` as an error.

## Notes
- Non-JSON endpoints (e.g. `/metrics`, static files, redirects) keep their existing HTTP semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized API response handling with unified response envelopes across all endpoints. All error and success responses now follow a consistent structure with standardized error codes and detailed messages. This ensures clients receive predictable, structured feedback across all interactions, improving API reliability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->